### PR TITLE
Add openssl-sys dependency for arm-unknown-linux-gnueabihf.

### DIFF
--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -20,6 +20,8 @@ path = "lib.rs"
   git = "https://github.com/sfackler/rust-openssl"
 [target.x86_64-unknown-linux-gnu.dependencies.openssl-sys]
   git = "https://github.com/sfackler/rust-openssl"
+[target.arm-unknown-linux-gnueabihf.dependencies.openssl-sys]
+  git = "https://github.com/sfackler/rust-openssl"
 [target.i686-unknown-freebsd.dependencies.openssl-sys]
   git = "https://github.com/sfackler/rust-openssl"
 [target.x86_64-unknown-freebsd.dependencies.openssl-sys]


### PR DESCRIPTION
Now it should build on ARM.
