### PR TITLE
Make `libssh2-sys` depend on `openssl-sys` for `aarch64-unknown-linux-gnu` triple as well

### DIFF
--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -23,6 +23,8 @@ openssl-sys = "0.2.0"
 openssl-sys = "0.2.0"
 [target.x86_64-unknown-linux-gnu.dependencies]
 openssl-sys = "0.2.0"
+[target.aarch64-unknown-linux-gnu.dependencies]
+openssl-sys = "0.2.0"
 [target.arm-unknown-linux-gnueabihf.dependencies]
 openssl-sys = "0.2.0"
 [target.i686-unknown-freebsd.dependencies]


### PR DESCRIPTION
As rust-lang/rust#19790 is hopefully landing soon, but rust-lang/cargo#1007 is still open, it would be good to add this dependency. (Now, cargo builds need manual touchups after pulls.)

(Similar to carllerche/curl-rust#48 and alexcrichton/git2-rs#35)
