### PR TITLE
Update to use openssl-sys 0.6.0

### DIFF
--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -17,23 +17,23 @@ libz-sys = "0.1.0"
 libc = "0.1"
 
 [target.i686-apple-darwin.dependencies]
-openssl-sys = "0.5.0"
+openssl-sys = "0.6.0"
 [target.x86_64-apple-darwin.dependencies]
-openssl-sys = "0.5.0"
+openssl-sys = "0.6.0"
 [target.i686-unknown-linux-gnu.dependencies]
-openssl-sys = "0.5.0"
+openssl-sys = "0.6.0"
 [target.x86_64-unknown-linux-gnu.dependencies]
-openssl-sys = "0.5.0"
+openssl-sys = "0.6.0"
 [target.aarch64-unknown-linux-gnu.dependencies]
-openssl-sys = "0.5.0"
+openssl-sys = "0.6.0"
 [target.arm-unknown-linux-gnueabihf.dependencies]
-openssl-sys = "0.5.0"
+openssl-sys = "0.6.0"
 [target.i686-unknown-freebsd.dependencies]
-openssl-sys = "0.5.0"
+openssl-sys = "0.6.0"
 [target.x86_64-unknown-freebsd.dependencies]
-openssl-sys = "0.5.0"
+openssl-sys = "0.6.0"
 [target.x86_64-unknown-dragonfly.dependencies]
-openssl-sys = "0.5.0"
+openssl-sys = "0.6.0"
 
 [build-dependencies]
 pkg-config = "0.3"


### PR DESCRIPTION
This brings the openssl in line with that used by hyper, for example.