### PR TITLE
Unpinned dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ libc = "*"
 
 [dependencies.libssh2-sys]
 path = "libssh2-sys"
-version = "0.1.0"
+version = "*"
 
 [dev-dependencies]
 tempdir = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ commands, forwarding local ports, etc.
 name = "all"
 
 [dependencies]
-bitflags = "0.1"
-libc = "0.1"
+bitflags = "*"
+libc = "*"
 
 [dependencies.libssh2-sys]
 path = "libssh2-sys"
 version = "0.1.0"
 
 [dev-dependencies]
-tempdir = "0.3"
+tempdir = "*"

--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -13,31 +13,31 @@ name = "libssh2_sys"
 path = "lib.rs"
 
 [dependencies]
-libz-sys = "0.1.0"
-libc = "0.1"
+libz-sys = "*"
+libc = "*"
 
 [target.i686-apple-darwin.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 [target.x86_64-apple-darwin.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 [target.i686-unknown-linux-gnu.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 [target.x86_64-unknown-linux-gnu.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 [target.aarch64-unknown-linux-gnu.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 [target.arm-unknown-linux-gnueabihf.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 [target.i686-unknown-freebsd.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 [target.x86_64-unknown-freebsd.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 [target.x86_64-unknown-dragonfly.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 [target.x86_64-unknown-bitrig.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 [target.x86_64-unknown-openbsd.dependencies]
-openssl-sys = "0.6.0"
+openssl-sys = "*"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "*"


### PR DESCRIPTION
The latest versions of the dependencies work on stable so unpinned them.  Noticed this because two versions of bitflags were being pulled into a project I'm working on.