### PR TITLE
Add iOS targets to Cargo.toml

### DIFF
--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -20,6 +20,16 @@ libc = "0.2"
 openssl-sys = ">= 0"
 [target.x86_64-apple-darwin.dependencies]
 openssl-sys = ">= 0"
+[target.i386-apple-ios.dependencies]
+openssl-sys = ">= 0"
+[target.x86_64-apple-ios.dependencies]
+openssl-sys = ">= 0"
+[target.aarch64-apple-ios.dependencies]
+openssl-sys = ">= 0"
+[target.armv7-apple-ios.dependencies]
+openssl-sys = ">= 0"
+[target.armv7s-apple-ios.dependencies]
+openssl-sys = ">= 0"
 [target.i686-unknown-linux-gnu.dependencies]
 openssl-sys = ">= 0"
 [target.i586-unknown-linux-gnu.dependencies]


### PR DESCRIPTION
Building for iOS, in addition to setting `OPENSSL_INCLUDE_DIR`, I also needed to add the cross-compiled OpenSSL prefix to `CMAKE_PREFIX_PATH` to get libssh2's CMake feature tests to link with the correct OpenSSL and not spuriously disable features.