### PR TITLE
Allow all non-negative return codes as Ok()

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -604,7 +604,7 @@ impl Session {
 
     /// Translate a return code into a Rust-`Result`.
     pub fn rc(&self, rc: c_int) -> Result<(), Error> {
-        if rc == 0 {
+        if rc >= 0 {
             Ok(())
         } else {
             match Error::last_error(self) {


### PR DESCRIPTION
All libssh2 functions that return a failure do so using a negative
value. However, some functions (for example:
https://www.libssh2.org/libssh2_channel_read_ex.html) might return a
positive value for success. We should recognize these positive values as
Ok() instead of Err().

This is consistent with what Stream<'channel, 'sess>::read and ::write
seem to expect in src/channel.rc.