### PR TITLE
libssh2 exit_status effectively never errors

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -199,11 +199,11 @@ impl<'sess> Channel<'sess> {
     /// Note that the exit status may not be available if the remote end has not
     /// yet set its status to closed.
     pub fn exit_status(&self) -> Result<i32, Error> {
-        let ret = unsafe { raw::libssh2_channel_get_exit_status(self.raw) };
-        match Error::last_error(self.sess) {
-            Some(err) => Err(err),
-            None => Ok(ret as i32)
-        }
+        // Should really store existing error, call function, check for error
+        // after and restore previous error if no new one...but the only error
+        // condition right now is a NULL pointer check on self.raw, so let's
+        // assume that's not the case.
+        Ok(unsafe { raw::libssh2_channel_get_exit_status(self.raw) })
     }
 
     /// Get the remote exit signal.


### PR DESCRIPTION
```
/*
 * libssh2_channel_get_exit_status
 *
 * Return the channel's program exit status. Note that the actual protocol
 * provides the full 32bit this function returns.  We cannot abuse it to
 * return error values in case of errors so we return a zero if channel is
 * NULL.
 */
LIBSSH2_API int
libssh2_channel_get_exit_status(LIBSSH2_CHANNEL *channel)
{
    if(!channel)
        return 0;

    return channel->exit_status;
}
```

Not a big implementation.
The problem with the previous code was that it was picking up unrelated errors from *previous* failures. This is particularly annoying when using async, since EAGAIN was sitting in the 'last error' location.

The comment describes a suggested 'ideal' way to fix this, but I think it's pretty unlikely that implementation is ever going to change.