### PR TITLE
ssh2::FileStat should derive Eq/PartialEq and Clone

### DIFF
--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -31,7 +31,7 @@ pub struct File<'sftp> {
 /// Metadata information about a remote file.
 ///
 /// Fields are not necessarily all provided
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 #[allow(missing_copy_implementations)]
 pub struct FileStat {
     /// File size, in bytes of the file.


### PR DESCRIPTION
Copy might constrain the implementation, but these are useful and shouldn't cause any difficulty in the future.