### PR TITLE
Fix libssh2 channel wait eof doc

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -288,7 +288,8 @@ impl<'sess> Channel<'sess> {
     }
 
     /// Artificially limit the number of bytes that will be read from this
-    /// channel.
+    /// channel. Hack intended for use by scp_recv only.
+    #[doc(hidden)]
     pub fn limit_read(&mut self, limit: u64) {
         self.read_limit = Some(limit);
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -309,7 +309,7 @@ impl<'sess> Channel<'sess> {
         }
     }
 
-    /// Wait for the remote end to acknowledge an EOF request.
+    /// Wait for the remote end to send EOF.
     pub fn wait_eof(&mut self) -> Result<(), Error> {
         unsafe { self.sess.rc(raw::libssh2_channel_wait_eof(self.raw)) }
     }


### PR DESCRIPTION
Upstream is slow, seems like it'd be useful to have the doc fix before 2050.

Also hidden `limit_read` per https://github.com/alexcrichton/ssh2-rs/issues/34#issuecomment-184880616, but I can remove that if you have another plan.