### PR TITLE
Use metadeps to specify pkg-config dependencies declaratively

### DIFF
--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -20,5 +20,8 @@ libc = "0.2"
 openssl-sys = "0.9"
 
 [build-dependencies]
-pkg-config = "0.3"
+metadeps = "1"
 cmake = "0.1.2"
+
+[package.metadata.pkg-config]
+libssh2 = "1.7.0"

--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -1,4 +1,4 @@
-extern crate pkg_config;
+extern crate metadeps;
 extern crate cmake;
 
 use std::env;
@@ -11,10 +11,7 @@ fn main() {
     register_dep("Z");
     register_dep("OPENSSL");
 
-    if let Ok(lib) = pkg_config::find_library("libssh2") {
-        for path in &lib.include_paths {
-            println!("cargo:include={}", path.display());
-        }
+    if metadeps::probe().is_ok() {
         return
     }
 


### PR DESCRIPTION
This makes it easier for distribution packaging tools to generate
appropriate package dependencies.