### PR TITLE
Added a remark about cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ the header files are:
 export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include
 export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib
 ```
+
+This crate also needs to have `cmake` installed:
+
+```sh
+brew install cmake
+```


### PR DESCRIPTION
I just tried to build this on a brand new Mac, which obviously doesn't have `cmake` installed.

I find it nice to declare the needed dependencies on the README, so I added a remark about `cmake`.