### PR TITLE
optionally use static or dynamic build of libssh2 from vcpkg

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,9 @@ environment:
     MSYS_BITS: 32
   - TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
+  - TARGET: x86_64-pc-windows-msvc
+    RUSTFLAGS: -Ctarget-feature=+crt-static
+    VCPKG_DEFAULT_TRIPLET: x64-windows-static
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
@@ -13,6 +16,10 @@ install:
   - if defined MSYS_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin
   - rustc -V
   - cargo -V
+  - if defined VCPKG_DEFAULT_TRIPLET git clone https://github.com/Microsoft/vcpkg c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET c:\projects\vcpkg\bootstrap-vcpkg.bat
+  - if defined VCPKG_DEFAULT_TRIPLET set VCPKG_ROOT=c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET %VCPKG_ROOT%\vcpkg.exe install libssh2
 
 build: false
 

--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -22,3 +22,6 @@ openssl-sys = "0.9"
 [build-dependencies]
 pkg-config = "0.3"
 cmake = "0.1.2"
+
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+vcpkg = "0.2"


### PR DESCRIPTION
This would be needed for https://github.com/alexcrichton/curl-rust/pull/166.
Not mergeable without https://github.com/alexcrichton/libz-sys/pull/17.

I had to add the "ssh2-link-helper" crate because I couldn't work out how to say "always depend on openssl-sys on unix, and optionally if it's an msvc build and this feature is enabled". Is there a better way to achieve that?