### PR TITLE
Fix exit_status example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@
 //! let mut s = String::new();
 //! channel.read_to_string(&mut s).unwrap();
 //! println!("{}", s);
+//! channel.wait_close();
 //! println!("{}", channel.exit_status().unwrap());
 //! ```
 //!

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -10,9 +10,23 @@ fn smoke() {
     channel.exec("true").unwrap();
     channel.wait_eof().unwrap();
     assert!(channel.eof());
-    assert_eq!(channel.exit_status().unwrap(), 0);
     channel.close().unwrap();
     channel.wait_close().unwrap();
+    assert_eq!(channel.exit_status().unwrap(), 0);
+    assert!(channel.eof());
+}
+
+#[test]
+fn bad_smoke() {
+    let (_tcp, sess) = ::authed_session();
+    let mut channel = sess.channel_session().unwrap();
+    channel.flush().unwrap();
+    channel.exec("false").unwrap();
+    channel.wait_eof().unwrap();
+    assert!(channel.eof());
+    channel.close().unwrap();
+    channel.wait_close().unwrap();
+    assert_eq!(channel.exit_status().unwrap(), 1);
     assert!(channel.eof());
 }
 


### PR DESCRIPTION
In the example in the documentation that calls exit_status and in the
smoke integration test exit_status is called before the channel is
closed and it will therefore always return Ok(0).

I have fixed this by calling wait_close() first and by adding a
bad_smoke test that executes false and checks that the exit_status is 1.