### PR TITLE
Support in-memory keypair.

### DIFF
--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -397,6 +397,15 @@ extern {
                                                   privatekey: *const c_char,
                                                   passphrase: *const c_char)
                                                   -> c_int;
+    pub fn libssh2_userauth_publickey_frommemory(sess: *mut LIBSSH2_SESSION,
+                                                 username: *const c_char,
+                                                 username_len: size_t,
+                                                 publickeydata: *const c_char,
+                                                 publickeydata_len: size_t,
+                                                 privatekeydata: *const c_char,
+                                                 privatekeydata_len: size_t,
+                                                 passphrase: *const c_char)
+                                                 -> c_int;
     pub fn libssh2_userauth_password_ex(session: *mut LIBSSH2_SESSION,
                                         username: *const c_char,
                                         username_len: c_uint,


### PR DESCRIPTION
Thanks for the writing this crate!

I happened to need this functionallity. This is tested only on Linux.
I took the idea for `#[cfg(unix)]` from the opened issue: https://github.com/alexcrichton/ssh2-rs/issues/77

Cheers,
Eldad