### PR TITLE
Tighten libz-sys lower bound

### DIFF
--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -13,7 +13,7 @@ name = "libssh2_sys"
 path = "lib.rs"
 
 [dependencies]
-libz-sys = ">= 0"
+libz-sys = "1"
 libc = "0.2"
 
 [target."cfg(unix)".dependencies]


### PR DESCRIPTION
Just one more step towards `-Z minimal-versions` being actually usable :) 