### PR TITLE
Add LIBSSH2_SYS_USE_PKG_CONFIG env var

### DIFF
--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -18,11 +18,13 @@ fn main() {
     register_dep("Z");
     register_dep("OPENSSL");
 
-    if let Ok(lib) = pkg_config::find_library("libssh2") {
-        for path in &lib.include_paths {
-            println!("cargo:include={}", path.display());
+    if env::var("LIBSSH2_SYS_USE_PKG_CONFIG").is_ok() {
+        if let Ok(lib) = pkg_config::find_library("libssh2") {
+            for path in &lib.include_paths {
+                println!("cargo:include={}", path.display());
+            }
+            return
         }
-        return
     }
 
     if !Path::new("libssh2/.git").exists() {

--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -18,6 +18,9 @@ fn main() {
     register_dep("Z");
     register_dep("OPENSSL");
 
+    // The system copy of libssh2 is not used by default because it
+    // can lead to having two copies of libssl loaded at once.
+    // See https://github.com/alexcrichton/ssh2-rs/pull/88
     if env::var("LIBSSH2_SYS_USE_PKG_CONFIG").is_ok() {
         if let Ok(lib) = pkg_config::find_library("libssh2") {
             for path in &lib.include_paths {


### PR DESCRIPTION
The latest actual release of libssh2 is old and broken. This uses the submodule instead unless you set `LIBSSH2_SYS_USE_PKG_CONFIG`. The mechanism is copied from libgit2.

I haven't tested this, because I don't know how to get cargo to build everything with these changes. :-/