### PR TITLE
Define LIBSSH2_DH_GEX_NEW to avoid KEX error

### DIFF
--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -105,6 +105,8 @@ fn main() {
         fs::write(build.join("libssh2_config.h"), &config).unwrap();
         cfg.include(&build);
     }
+    /* Enable newer diffie-hellman-group-exchange-sha1 syntax */
+    cfg.define("LIBSSH2_DH_GEX_NEW", None);
 
     cfg.define("LIBSSH2_HAVE_ZLIB", None);
     if let Some(path) = env::var_os("DEP_Z_INCLUDE") {


### PR DESCRIPTION
When `LIBSSH2_DH_GEX_NEW` is not defined LIBSSH2 will use an old `diffie-hellman-group-exchange-sha1` syntax that has been removed from newer versions of OpenSSH which will cause the handshake to fail. The error in the sshd log when this happens is `error: kex protocol error: type 30 seq 1 [preauth]`

When compiling libssh2 normally with CMake `LIBSSH2_DH_GEX_NEW` is defined because the option `ENABLE_GEX_NEW=ON` is the default as described [here](https://github.com/libssh2/libssh2/blob/master/docs/INSTALL_CMAKE)