### PR TITLE
Normalize to Unix-style path separators

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::Path;
 
 use {raw, Session, Error};
@@ -28,22 +29,36 @@ pub trait SessionBinding<'sess>: Sized {
 }
 
 #[cfg(unix)]
-pub fn path2bytes(p: &Path) -> Result<&[u8], Error> {
+pub fn path2bytes(p: &Path) -> Result<Cow<[u8]>, Error> {
     use std::os::unix::prelude::*;
     use std::ffi::OsStr;
     let s: &OsStr = p.as_ref();
-    check(s.as_bytes())
+    check(Cow::Borrowed(s.as_bytes()))
 }
 #[cfg(windows)]
-pub fn path2bytes(p: &Path) -> Result<&[u8], Error> {
-    match p.to_str() {
-        Some(s) => check(s.as_bytes()),
-        None => Err(Error::new(raw::LIBSSH2_ERROR_INVAL,
-                               "only unicode paths on windows may be used")),
-    }
+pub fn path2bytes(p: &Path) -> Result<Cow<[u8]>, Error> {
+    p.to_str()
+        .map(|s| s.as_bytes())
+        .ok_or_else(|| Error::new(raw::LIBSSH2_ERROR_INVAL,
+                                  "only unicode paths on windows may be used"))
+        .map(|bytes| {
+            if bytes.contains(&b'\\') {
+                // Normalize to Unix-style path separators
+                let mut bytes = bytes.to_owned();
+                for b in &mut bytes {
+                    if *b == b'\\' {
+                        *b = b'/';
+                    }
+                }
+                Cow::Owned(bytes)
+            } else {
+                Cow::Borrowed(bytes)
+            }
+        })
+        .and_then(check)
 }
 
-fn check(b: &[u8]) -> Result<&[u8], Error> {
+fn check(b: Cow<[u8]>) -> Result<Cow<[u8]>, Error> {
     if b.iter().any(|b| *b == 0) {
         Err(Error::new(raw::LIBSSH2_ERROR_INVAL,
                        "path provided contains a 0 byte"))


### PR DESCRIPTION
This addresses issue #99 and is hugely based on the [tar implementation](https://github.com/alexcrichton/tar-rs/blob/master/src/header.rs#L1538). 