### PR TITLE
Add script for running integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+/tests/sshd

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,9 @@ matrix:
         on:
           branch: master
 
-before_script:
-  - ssh-keygen -t rsa -f ~/.ssh/id_rsa -N "" -q
-  - eval `ssh-agent -s`
-  - ssh-add ~/.ssh/id_rsa
-  - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-  - echo "Host localhost" >> ~/.ssh/config
-  - echo "  StrictHostKeyChecking no" >> ~/.ssh/config
-  - chmod 600 ~/.ssh/authorized_keys
-  - ssh -v localhost echo hello
-
 script:
   - cargo build
-  - cargo test
+  - tests/run_integration_tests.sh
   - rustdoc --test README.md -L target
   - cargo run --manifest-path systest/Cargo.toml
 

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -13,7 +13,10 @@ mod knownhosts;
 mod sftp;
 
 pub fn socket() -> TcpStream {
-    TcpStream::connect("127.0.0.1:22").unwrap()
+    let port = env::var("RUST_SSH2_FIXTURE_PORT")
+        .map(|s| s.parse().unwrap())
+        .unwrap_or(22);
+    TcpStream::connect(&format!("127.0.0.1:{}", port)).unwrap()
 }
 
 pub fn authed_session() -> (TcpStream, ssh2::Session) {

--- a/tests/all/session.rs
+++ b/tests/all/session.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tempdir::TempDir;
 
 use ssh2::{Session, MethodType, HashType};
@@ -56,10 +56,14 @@ fn keepalive() {
 #[test]
 fn scp_recv() {
     let (_tcp, sess) = ::authed_session();
-    let (mut ch, _) = sess.scp_recv(Path::new(".ssh/authorized_keys")).unwrap();
+
+    // Download our own source file; it's the only path that
+    // we know for sure exists on this system.
+    let p = Path::new(file!()).canonicalize().unwrap();
+
+    let (mut ch, _) = sess.scp_recv(&p).unwrap();
     let mut data = String::new();
     ch.read_to_string(&mut data).unwrap();
-    let p = PathBuf::from(env::var("HOME").unwrap()).join(".ssh/authorized_keys");
     let mut expected = String::new();
     File::open(&p).unwrap().read_to_string(&mut expected).unwrap();
     assert!(data == expected);

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+# This script spawns an ssh daemon with a known configuration so that we can
+# test various functionality against it.
+
+# Tell the tests to use the port number we're using to spawn this server
+export RUST_SSH2_FIXTURE_PORT=8022
+
+cleanup() {
+  # Stop the ssh server
+  kill $(< $SSHDIR/sshd.pid)
+  # Stop local ssh agent
+  kill $SSH_AGENT_PID
+}
+trap cleanup EXIT
+
+# Blow away any prior state and re-configure our test server
+SSHDIR=$(pwd)/tests/sshd
+
+rm -rf $SSHDIR
+mkdir -p $SSHDIR
+
+eval $(ssh-agent -s)
+
+ssh-keygen -t rsa -f $SSHDIR/id_rsa -N "" -q
+chmod 0600 $SSHDIR/id_rsa*
+ssh-add $SSHDIR/id_rsa
+cp $SSHDIR/id_rsa.pub $SSHDIR/authorized_keys
+
+ssh-keygen -f $SSHDIR/ssh_host_rsa_key -N '' -t rsa
+
+cat > $SSHDIR/sshd_config <<-EOT
+AuthorizedKeysFile=$SSHDIR/authorized_keys
+HostKey=$SSHDIR/ssh_host_rsa_key
+PidFile=$SSHDIR/sshd.pid
+Subsystem sftp /usr/libexec/sftp-server
+UsePAM yes
+X11Forwarding yes
+PrintMotd yes
+PermitTunnel yes
+AllowTcpForwarding yes
+MaxStartups 500
+EOT
+
+# Start an ssh server
+/usr/sbin/sshd -p $RUST_SSH2_FIXTURE_PORT -f $SSHDIR/sshd_config -E /dev/stderr &
+# Give it a moment to start up
+sleep 2
+
+# Run the tests against it
+RUST_BACKTRACE=1 cargo test --all


### PR DESCRIPTION
This makes it possible to run the integration tests without
requiring that the user change their local ssh configuration.
This is desirable because some sites have strict controls over
the local ssh configuration files.

This commit adds a script that spawns a local copy of the ssh
daemon running on an alternate port with a specific configuration
that is known to successfully pass the test suite.