### PR TITLE
Support keyboard-interactive authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ vendored-openssl = ["libssh2-sys/vendored-openssl"]
 [dependencies]
 bitflags = "1.0.4"
 libc = "0.2"
-libssh2-sys = { path = "libssh2-sys", version = "0.2.4" }
+libssh2-sys = { path = "libssh2-sys", version = "0.2.12" }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libssh2-sys"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "ssh2"
 build = "build.rs"

--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -248,6 +248,30 @@ pub type LIBSSH2_PASSWD_CHANGEREQ_FUNC = extern "C" fn(
     abstrakt: *mut *mut c_void,
 );
 
+pub type LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC = extern "C" fn(
+    username: *const c_char,
+    username_len: c_int,
+    instruction: *const c_char,
+    instruction_len: c_int,
+    num_prompts: c_int,
+    prompts: *const LIBSSH2_USERAUTH_KBDINT_PROMPT,
+    responses: *mut LIBSSH2_USERAUTH_KBDINT_RESPONSE,
+    abstrakt: *mut *mut c_void,
+);
+
+#[repr(C)]
+pub struct LIBSSH2_USERAUTH_KBDINT_PROMPT {
+    pub text: *mut c_char,
+    pub length: c_uint,
+    pub echo: c_uchar,
+}
+
+#[repr(C)]
+pub struct LIBSSH2_USERAUTH_KBDINT_RESPONSE {
+    pub text: *mut c_char,
+    pub length: c_uint,
+}
+
 #[cfg(unix)]
 pub type libssh2_socket_t = c_int;
 #[cfg(all(windows, target_arch = "x86"))]
@@ -269,6 +293,7 @@ extern "C" {
         realloc: Option<LIBSSH2_REALLOC_FUNC>,
         abstrakt: *mut c_void,
     ) -> *mut LIBSSH2_SESSION;
+    pub fn libssh2_session_abstract(session: *mut LIBSSH2_SESSION) -> *mut *mut c_void;
     pub fn libssh2_session_free(sess: *mut LIBSSH2_SESSION) -> c_int;
     pub fn libssh2_session_banner_get(sess: *mut LIBSSH2_SESSION) -> *const c_char;
     pub fn libssh2_session_banner_set(sess: *mut LIBSSH2_SESSION, banner: *const c_char) -> c_int;
@@ -480,6 +505,12 @@ extern "C" {
         password: *const c_char,
         password_len: c_uint,
         password_change_cb: Option<LIBSSH2_PASSWD_CHANGEREQ_FUNC>,
+    ) -> c_int;
+    pub fn libssh2_userauth_keyboard_interactive_ex(
+        session: *mut LIBSSH2_SESSION,
+        username: *const c_char,
+        username_len: c_uint,
+        callback: Option<LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC>,
     ) -> c_int;
 
     // knownhost

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ pub use error::Error;
 pub use knownhosts::{Host, Hosts, KnownHosts};
 pub use listener::Listener;
 use session::SessionInner;
-pub use session::{ScpFileStat, Session};
+pub use session::{KeyboardInteractivePrompt, Prompt, ScpFileStat, Session};
 pub use sftp::{File, FileStat, FileType, OpenType};
 pub use sftp::{OpenFlags, RenameFlags, Sftp};
 pub use DisconnectCode::{AuthCancelledByUser, TooManyConnections};

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -15,7 +15,11 @@ fn main() {
                 s.to_string()
             }
         })
-        .skip_type(|t| t.ends_with("FUNC"))
-        .skip_fn(|f| f == "libssh2_userauth_password_ex" || f == "libssh2_session_init_ex");
+        .skip_type(|t| t.ends_with("FUNC") || t.contains("KBDINT"))
+        .skip_fn(|f| {
+            f == "libssh2_userauth_password_ex"
+                || f == "libssh2_session_init_ex"
+                || f == "libssh2_userauth_keyboard_interactive_ex"
+        });
     cfg.generate("../libssh2-sys/lib.rs", "all.rs");
 }

--- a/tests/all/channel.rs
+++ b/tests/all/channel.rs
@@ -14,6 +14,9 @@ fn consume_stdio(channel: &mut Channel) -> (String, String) {
     let mut stderr = String::new();
     channel.stderr().read_to_string(&mut stderr).unwrap();
 
+    eprintln!("stdout: {}", stdout);
+    eprintln!("stderr: {}", stderr);
+
     (stdout, stderr)
 }
 
@@ -88,9 +91,14 @@ fn eof() {
 fn shell() {
     let sess = ::authed_session();
     let mut channel = sess.channel_session().unwrap();
+    eprintln!("requesting pty");
     channel.request_pty("xterm", None, None).unwrap();
+    eprintln!("shell");
     channel.shell().unwrap();
+    eprintln!("close");
     channel.close().unwrap();
+    eprintln!("done");
+    consume_stdio(&mut channel);
 }
 
 #[test]

--- a/tests/all/session.rs
+++ b/tests/all/session.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::path::Path;
 use tempdir::TempDir;
 
-use ssh2::{HashType, MethodType, Session};
+use ssh2::{HashType, KeyboardInteractivePrompt, MethodType, Prompt, Session};
 
 #[test]
 fn smoke() {
@@ -45,6 +45,77 @@ fn smoke_handshake() {
     }
     assert!(sess.authenticated());
     sess.host_key_hash(HashType::Md5).unwrap();
+}
+
+#[test]
+fn keyboard_interactive() {
+    let user = env::var("USER").unwrap();
+    let socket = ::socket();
+    let mut sess = Session::new().unwrap();
+    sess.handshake(socket).unwrap();
+    sess.host_key().unwrap();
+    let methods = sess.auth_methods(&user).unwrap();
+    assert!(methods.contains("keyboard-interactive"), "{}", methods);
+    assert!(!sess.authenticated());
+
+    // We don't know the correct response for whatever challenges
+    // will be returned to us, but that's ok; the purpose of this
+    // test is to check that we have some basically sane interaction
+    // with the library.
+
+    struct Prompter {
+        some_data: usize,
+    }
+
+    impl KeyboardInteractivePrompt for Prompter {
+        fn prompt<'a>(
+            &mut self,
+            username: &str,
+            instructions: &str,
+            prompts: &[Prompt<'a>],
+        ) -> Vec<String> {
+            // Sanity check that the pointer manipulation resolves and
+            // we read back our member data ok
+            assert_eq!(self.some_data, 42);
+
+            eprintln!("username: {}", username);
+            eprintln!("instructions: {}", instructions);
+            eprintln!("prompts: {:?}", prompts);
+
+            // Unfortunately, we can't make any assertions about username
+            // or instructions, as they can be empty (on my linux system)
+            // or may have arbitrary contents
+            // assert_eq!(username, env::var("USER").unwrap());
+            // assert!(!instructions.is_empty());
+
+            // Hopefully this isn't too brittle an assertion
+            if prompts.len() == 1 {
+                assert_eq!(prompts.len(), 1);
+                // Might be "Password: " or "Password:" or other variations
+                assert!(prompts[0].text.contains("sword"));
+                assert_eq!(prompts[0].echo, false);
+            } else {
+                // maybe there's some PAM configuration that results
+                // in multiple prompts. We can't make any real assertions
+                // in this case, other than that there has to be at least
+                // one prompt.
+                assert!(!prompts.is_empty());
+            }
+
+            prompts.iter().map(|_| "bogus".to_string()).collect()
+        }
+    }
+
+    let mut p = Prompter { some_data: 42 };
+
+    match sess.userauth_keyboard_interactive(&user, &mut p) {
+        Ok(_) => eprintln!("auth succeeded somehow(!)"),
+        Err(err) => eprintln!("auth failed as expected: {}", err),
+    };
+
+    // The only way this assertion will be false is if the person
+    // running these tests has "bogus" as their password
+    assert!(!sess.authenticated());
 }
 
 #[test]

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -60,4 +60,4 @@ sleep 2
 
 # Run the tests against it
 cargo test --all
-cargo test --features vendored-openssl
+cargo test --features vendored-openssl -- --nocapture

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -46,6 +46,7 @@ UsePAM yes
 X11Forwarding yes
 PrintMotd yes
 PermitTunnel yes
+KbdInteractiveAuthentication yes
 AllowTcpForwarding yes
 MaxStartups 500
 # Relax modes when the repo is under eg: /var/tmp


### PR DESCRIPTION
There's magic happening in the systest stuff that I couldn't trace; I couldn't find information on how it generates the C code that it compiles, and it seems to trip over the other existing function types, so I arranged for those that I added here to be skipped too.

For the prompt callback; I chose to implement this using a trait object.  This is a combination of flexible and more easily documentable.  My use case is embedding this into a terminal emulator and I'd like to be able to associate the callback and prompt information with the relevant portion of the UI, so having that context available is highly desirable.

I've included an integration test that shows that things basically work, although we can't have the test end-to-end successfully use interactive auth because we don't know the password of the user running the test(!)

https://github.com/alexcrichton/ssh2-rs/issues/65