### PR TITLE
Fix SCP transfer from hanging indefinitely on Windows. Fixes #107, Fixes 109

### DIFF
--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -491,9 +491,6 @@ extern {
                                   -> *mut LIBSSH2_KNOWNHOSTS;
 
     // scp
-    pub fn libssh2_scp_recv(sess: *mut LIBSSH2_SESSION,
-                            path: *const c_char,
-                            sb: *mut libc::stat) -> *mut LIBSSH2_CHANNEL;
     pub fn libssh2_scp_recv2(sess: *mut LIBSSH2_SESSION,
                             path: *const c_char,
                             sb: *mut libc::stat) -> *mut LIBSSH2_CHANNEL;

--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -494,6 +494,9 @@ extern {
     pub fn libssh2_scp_recv(sess: *mut LIBSSH2_SESSION,
                             path: *const c_char,
                             sb: *mut libc::stat) -> *mut LIBSSH2_CHANNEL;
+    pub fn libssh2_scp_recv2(sess: *mut LIBSSH2_SESSION,
+                            path: *const c_char,
+                            sb: *mut libc::stat) -> *mut LIBSSH2_CHANNEL;
     pub fn libssh2_scp_send64(sess: *mut LIBSSH2_SESSION,
                               path: *const c_char,
                               mode: c_int,

--- a/src/session.rs
+++ b/src/session.rs
@@ -462,7 +462,7 @@ impl Session {
         let path = try!(CString::new(try!(util::path2bytes(path))));
         unsafe {
             let mut sb: libc::stat = mem::zeroed();
-            let ret = raw::libssh2_scp_recv(self.raw, path.as_ptr(), &mut sb);
+            let ret = raw::libssh2_scp_recv2(self.raw, path.as_ptr(), &mut sb);
             let mut c: Channel = try!(SessionBinding::from_raw_opt(self, ret));
 
             // Hm, apparently when we scp_recv() a file the actual channel

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -18,6 +18,7 @@ fn main() {
         .skip_type(|t| t.ends_with("FUNC"))
         .skip_fn(|f| {
             f == "libssh2_userauth_password_ex" ||
+                f == "libssh2_scp_recv2" ||
                 f == "libssh2_session_init_ex"
         });
     cfg.generate("../libssh2-sys/lib.rs", "all.rs");


### PR DESCRIPTION
`libssh2_scp_recv` was deprecated in libssh2. `libssh2_scp_recv2` was
introduced with large file support on windows. Calling `libssh2_scp_recv`
was returning a stat object with the current timestamp as the remote file size
causing the file download to hang indefinitely.