### PR TITLE
libssh2-sys: add `vendored` feature to build openssl-src

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_script:
 
 script:
   - cargo build
+  - cargo test --features vendored-openssl
   - cargo test
   - rustdoc --test README.md -L target
   - cargo run --manifest-path systest/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ Bindings to libssh2 for interacting with SSH servers and executing remote
 commands, forwarding local ports, etc.
 """
 
+[features]
+vendored-openssl = ["libssh2-sys/vendored-openssl"]
+
 [dependencies]
 bitflags = "1.0.4"
 libc = "0.2"

--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -12,6 +12,9 @@ description = "Native bindings to the libssh2 library"
 name = "libssh2_sys"
 path = "lib.rs"
 
+[features]
+vendored-openssl = ["openssl-sys/vendored"]
+
 [dependencies]
 libz-sys = "1.0.21"
 libc = "0.2"


### PR DESCRIPTION
This enables building `ssh2` and `libssh2-sys` with the `vendored`
feature, which in turn causes openssl to be built and linked locally,
and does not require that homebrew or some other externally provided
version of openssl be made available.

It does require a working C compiler, perl and make.