### PR TITLE
Expose more known_hosts related constants

### DIFF
--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -33,6 +33,10 @@ pub const LIBSSH2_FLAG_COMPRESS: c_int = 2;
 pub const LIBSSH2_HOSTKEY_TYPE_UNKNOWN: c_int = 0;
 pub const LIBSSH2_HOSTKEY_TYPE_RSA: c_int = 1;
 pub const LIBSSH2_HOSTKEY_TYPE_DSS: c_int = 2;
+pub const LIBSSH2_HOSTKEY_TYPE_ECDSA_256: c_int = 3;
+pub const LIBSSH2_HOSTKEY_TYPE_ECDSA_384: c_int = 4;
+pub const LIBSSH2_HOSTKEY_TYPE_ECDSA_521: c_int = 5;
+pub const LIBSSH2_HOSTKEY_TYPE_ED25519: c_int = 6;
 
 pub const LIBSSH2_METHOD_KEX: c_int = 0;
 pub const LIBSSH2_METHOD_HOSTKEY: c_int = 1;
@@ -120,6 +124,7 @@ pub const LIBSSH2_FX_LINK_LOOP: c_int = 21;
 
 pub const LIBSSH2_HOSTKEY_HASH_MD5: c_int = 1;
 pub const LIBSSH2_HOSTKEY_HASH_SHA1: c_int = 2;
+pub const LIBSSH2_HOSTKEY_HASH_SHA256: c_int = 3;
 
 pub const LIBSSH2_KNOWNHOST_FILE_OPENSSH: c_int = 1;
 
@@ -139,6 +144,7 @@ pub const LIBSSH2_KNOWNHOST_KEY_SSHDSS: c_int = 3 << 18;
 pub const LIBSSH2_KNOWNHOST_KEY_ECDSA_256: c_int = 4 << 18;
 pub const LIBSSH2_KNOWNHOST_KEY_ECDSA_384: c_int = 5 << 18;
 pub const LIBSSH2_KNOWNHOST_KEY_ECDSA_521: c_int = 6 << 18;
+pub const LIBSSH2_KNOWNHOST_KEY_ED25519: c_int = 7 << 18;
 pub const LIBSSH2_KNOWNHOST_KEY_UNKNOWN: c_int = 15 << 18;
 
 pub const LIBSSH2_FXF_READ: c_ulong = 0x00000001;

--- a/src/knownhosts.rs
+++ b/src/knownhosts.rs
@@ -39,11 +39,7 @@ use util::{self, Binding, SessionBinding};
 ///
 ///     println!("adding {} to the known hosts", host);
 ///
-///     known_hosts.add(host, key, host, match key_type {
-///         HostKeyType::Rsa => KnownHostKeyFormat::SshRsa,
-///         HostKeyType::Dss => KnownHostKeyFormat::SshDss,
-///         HostKeyType::Unknown => panic!("unknown type of key!"),
-///     }).unwrap();
+///     known_hosts.add(host, key, host, key_type.into()).unwrap();
 ///     known_hosts.write_file(&file, KnownHostFileKind::OpenSSH).unwrap();
 /// }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,11 +199,15 @@ pub enum DisconnectCode {
 }
 
 #[allow(missing_docs)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum HostKeyType {
     Unknown = raw::LIBSSH2_HOSTKEY_TYPE_UNKNOWN as isize,
     Rsa = raw::LIBSSH2_HOSTKEY_TYPE_RSA as isize,
     Dss = raw::LIBSSH2_HOSTKEY_TYPE_DSS as isize,
+    Ecdsa256 = raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_256 as isize,
+    Ecdsa384 = raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_384 as isize,
+    Ecdsa521 = raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_521 as isize,
+    Ed255219 = raw::LIBSSH2_HOSTKEY_TYPE_ED25519 as isize,
 }
 
 #[allow(missing_docs)]
@@ -230,20 +234,21 @@ pub static FLUSH_ALL: i32 = -2;
 pub static EXTENDED_DATA_STDERR: i32 = 1;
 
 #[allow(missing_docs)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum HashType {
     Md5 = raw::LIBSSH2_HOSTKEY_HASH_MD5 as isize,
-    Sha1 = raw:: LIBSSH2_HOSTKEY_HASH_SHA1 as isize,
+    Sha1 = raw::LIBSSH2_HOSTKEY_HASH_SHA1 as isize,
+    Sha256 = raw::LIBSSH2_HOSTKEY_HASH_SHA256 as isize,
 }
 
 #[allow(missing_docs)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum KnownHostFileKind {
     OpenSSH = raw::LIBSSH2_KNOWNHOST_FILE_OPENSSH as isize,
 }
 
 /// Possible results of a call to `KnownHosts::check`
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum CheckResult {
     /// Hosts and keys match
     Match = raw::LIBSSH2_KNOWNHOST_CHECK_MATCH as isize,
@@ -256,9 +261,28 @@ pub enum CheckResult {
 }
 
 #[allow(missing_docs)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum KnownHostKeyFormat {
+    Unknown = raw::LIBSSH2_KNOWNHOST_KEY_UNKNOWN as isize,
     Rsa1 = raw::LIBSSH2_KNOWNHOST_KEY_RSA1 as isize,
     SshRsa = raw::LIBSSH2_KNOWNHOST_KEY_SSHRSA as isize,
     SshDss = raw::LIBSSH2_KNOWNHOST_KEY_SSHDSS as isize,
+    Ecdsa256 = raw::LIBSSH2_KNOWNHOST_KEY_ECDSA_256 as isize,
+    Ecdsa384 = raw::LIBSSH2_KNOWNHOST_KEY_ECDSA_384 as isize,
+    Ecdsa521 = raw::LIBSSH2_KNOWNHOST_KEY_ECDSA_521 as isize,
+    Ed255219 = raw::LIBSSH2_KNOWNHOST_KEY_ED25519 as isize,
+}
+
+impl From<HostKeyType> for KnownHostKeyFormat {
+    fn from(host_type: HostKeyType) -> KnownHostKeyFormat {
+        match host_type {
+            HostKeyType::Unknown => KnownHostKeyFormat::Unknown,
+            HostKeyType::Rsa => KnownHostKeyFormat::SshRsa,
+            HostKeyType::Dss => KnownHostKeyFormat::SshDss,
+            HostKeyType::Ecdsa256 => KnownHostKeyFormat::Ecdsa256,
+            HostKeyType::Ecdsa384 => KnownHostKeyFormat::Ecdsa384,
+            HostKeyType::Ecdsa521 => KnownHostKeyFormat::Ecdsa521,
+            HostKeyType::Ed255219 => KnownHostKeyFormat::Ed255219,
+        }
+    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -565,6 +565,11 @@ impl Session {
             let kind = match kind {
                 raw::LIBSSH2_HOSTKEY_TYPE_RSA => HostKeyType::Rsa,
                 raw::LIBSSH2_HOSTKEY_TYPE_DSS => HostKeyType::Dss,
+                raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_256 => HostKeyType::Ecdsa256,
+                raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_384 => HostKeyType::Ecdsa384,
+                raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_521 => HostKeyType::Ecdsa521,
+                raw::LIBSSH2_HOSTKEY_TYPE_ED25519 => HostKeyType::Ed255219,
+                raw::LIBSSH2_HOSTKEY_TYPE_UNKNOWN => HostKeyType::Unknown,
                 _ => HostKeyType::Unknown,
             };
             Some((data, kind))
@@ -579,6 +584,7 @@ impl Session {
         let len = match hash {
             HashType::Md5 => 16,
             HashType::Sha1 => 20,
+            HashType::Sha256 => 32,
         };
         unsafe {
             let ret = raw::libssh2_hostkey_hash(self.raw, hash as c_int);


### PR DESCRIPTION
This brings us up to date with the current set of host key and known
host key enum variants so that we can parse and edit current openssh
known_hosts files.

This also adds a convenience `From` impl that allows converting from
the host key type to a known hosts entry type.