### PR TITLE
Fix scp_recv ABI issue on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ vendored-openssl = ["libssh2-sys/vendored-openssl"]
 [dependencies]
 bitflags = "1.0.4"
 libc = "0.2"
-libssh2-sys = { path = "libssh2-sys", version = "0.2.4" }
+libssh2-sys = { path = "libssh2-sys", version = "0.2.12" }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libssh2-sys"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "ssh2"
 build = "build.rs"

--- a/src/session.rs
+++ b/src/session.rs
@@ -533,8 +533,8 @@ impl Session {
     pub fn scp_recv(&self, path: &Path) -> Result<(Channel, ScpFileStat), Error> {
         let path = try!(CString::new(try!(util::path2bytes(path))));
         unsafe {
-            let mut sb: libc::stat = mem::zeroed();
-            let ret = raw::libssh2_scp_recv(self.inner.raw, path.as_ptr(), &mut sb);
+            let mut sb: raw::libssh2_struct_stat = mem::zeroed();
+            let ret = raw::libssh2_scp_recv2(self.inner.raw, path.as_ptr(), &mut sb);
             let mut c = Channel::from_raw_opt(ret, &self.inner)?;
 
             // Hm, apparently when we scp_recv() a file the actual channel
@@ -543,7 +543,7 @@ impl Session {
             // artificially limit the channel to a certain amount of bytes that
             // can be read.
             c.limit_read(sb.st_size as u64);
-            Ok((c, ScpFileStat { stat: sb }))
+            Ok((c, ScpFileStat { stat: *sb }))
         }
     }
 

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -9,9 +9,18 @@ fn main() {
         .header("libssh2_sftp.h")
         .include(env::var("DEP_SSH2_INCLUDE").unwrap())
         .type_name(|s, is_struct| {
-            if (is_struct || s == "stat") && !s.starts_with("LIB") {
+            if s == "stat" {
+                // Ensure that we emit `struct stat` rather than just a `stat` typedef.
+                format!("struct stat")
+            } else if s == "libssh2_struct_stat" {
+                // libssh2_struct_stat is a typedef so ensure that we don't emit
+                // `struct libssh2_struct_stat` in the C code we generate
+                s.to_string()
+            } else if is_struct && !s.starts_with("LIB") {
+                // Otherwise we prefer to emit `struct foo` unless the type is `LIB_XXX`
                 format!("struct {}", s)
             } else {
+                // All other cases: just emit the type name
                 s.to_string()
             }
         })


### PR DESCRIPTION
* Adopt scp_recv2 instead, which uses compatible 64-bit stat types
* Mark scp_recv as deprecated
* small version bump

Fixes https://github.com/alexcrichton/ssh2-rs/issues/109
Refs https://github.com/alexcrichton/ssh2-rs/pull/117

Co-authored-by: Joyce Babu <joyce@ennexa.com>