### PR TITLE
Cutting libssh2-sys and ssh2 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libssh2-sys/libssh2"]
 	path = libssh2-sys/libssh2
-	url = https://github.com/alexcrichton/libssh2
+	url = https://github.com/wez/libssh2
+	branch = win10pr

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Rust bindings to libssh2, an ssh client library.
 ```toml
 # Cargo.toml
 [dependencies]
-ssh2 = "0.3"
+ssh2 = "0.4"
 ```
 
 ## Building on OSX 10.10+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 image:
   - Visual Studio 2019
+  - Visual Studio 2017
+  - Visual Studio 2015
+
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image:
-  - Visual Studio 2017
+  - Visual Studio 2019
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image:
+  - Visual Studio 2017
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc

--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -164,7 +164,6 @@ fn main() {
         println!("cargo:rustc-link-lib=bcrypt");
         println!("cargo:rustc-link-lib=crypt32");
         println!("cargo:rustc-link-lib=user32");
-        println!("cargo:rustc-link-lib=ntdll");
     }
 }
 

--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -164,6 +164,7 @@ fn main() {
         println!("cargo:rustc-link-lib=bcrypt");
         println!("cargo:rustc-link-lib=crypt32");
         println!("cargo:rustc-link-lib=user32");
+        println!("cargo:rustc-link-lib=ntdll");
     }
 }
 

--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -165,6 +165,7 @@ fn main() {
         println!("cargo:rustc-link-lib=crypt32");
         println!("cargo:rustc-link-lib=user32");
         println!("cargo:rustc-link-lib=ntdll");
+        println!("cargo:rustc-link-lib=ntoskrnl");
     }
 }
 

--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -165,7 +165,6 @@ fn main() {
         println!("cargo:rustc-link-lib=crypt32");
         println!("cargo:rustc-link-lib=user32");
         println!("cargo:rustc-link-lib=ntdll");
-        println!("cargo:rustc-link-lib=ntoskrnl");
     }
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -70,7 +70,7 @@ impl Agent {
 
     /// Attempt public key authentication with the help of ssh-agent.
     pub fn userauth(&self, username: &str, identity: &PublicKey) -> Result<(), Error> {
-        let username = try!(CString::new(username));
+        let username = CString::new(username)?;
         unsafe {
             self.sess.rc(raw::libssh2_agent_userauth(
                 self.raw,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -263,7 +263,7 @@ impl Channel {
                 &mut lang,
                 &mut langlen,
             );
-            try!(self.sess.rc(rc));
+            self.sess.rc(rc)?;
             return Ok(ExitSignal {
                 exit_signal: convert(self, sig, siglen),
                 error_message: convert(self, msg, msglen),
@@ -325,7 +325,7 @@ impl Channel {
                 &mut ret,
             )
         };
-        try!(self.sess.rc(rc));
+        self.sess.rc(rc)?;
         Ok(ret as u64)
     }
 

--- a/src/knownhosts.rs
+++ b/src/knownhosts.rs
@@ -79,10 +79,10 @@ impl KnownHosts {
     /// Reads a collection of known hosts from a specified file and adds them to
     /// the collection of known hosts.
     pub fn read_file(&mut self, file: &Path, kind: KnownHostFileKind) -> Result<u32, Error> {
-        let file = try!(CString::new(try!(util::path2bytes(file))));
+        let file = CString::new(util::path2bytes(file)?)?;
         let n = unsafe { raw::libssh2_knownhost_readfile(self.raw, file.as_ptr(), kind as c_int) };
         if n < 0 {
-            try!(self.sess.rc(n))
+            self.sess.rc(n)?
         }
         Ok(n as u32)
     }
@@ -102,7 +102,7 @@ impl KnownHosts {
     /// Writes all the known hosts to the specified file using the specified
     /// file format.
     pub fn write_file(&self, file: &Path, kind: KnownHostFileKind) -> Result<(), Error> {
-        let file = try!(CString::new(try!(util::path2bytes(file))));
+        let file = CString::new(util::path2bytes(file)?)?;
         let n = unsafe { raw::libssh2_knownhost_writefile(self.raw, file.as_ptr(), kind as c_int) };
         self.sess.rc(n)
     }
@@ -126,7 +126,7 @@ impl KnownHosts {
                     // + 1 for the trailing zero
                     v.reserve(outlen as usize + 1);
                 } else {
-                    try!(self.sess.rc(rc));
+                    self.sess.rc(rc)?;
                     v.set_len(outlen as usize);
                     break;
                 }
@@ -202,7 +202,7 @@ impl KnownHosts {
         comment: &str,
         fmt: ::KnownHostKeyFormat,
     ) -> Result<(), Error> {
-        let host = try!(CString::new(host));
+        let host = CString::new(host)?;
         let flags =
             raw::LIBSSH2_KNOWNHOST_TYPE_PLAIN | raw::LIBSSH2_KNOWNHOST_KEYENC_RAW | (fmt as c_int);
         unsafe {


### PR DESCRIPTION
@alexcrichton just want to run this one by you before I publish to crates.io; this will publish the `-sys` changes you've already reviewed, but this also updates the bundled libssh2 to my fork which includes a fix for DH kex on Windows 10 that is tracked over here: https://github.com/libssh2/libssh2/pull/397

That fix is specific to Windows 10 and will probe and use the older method for older versions of windows.  That PR has some commentary about the method for detecting Windows 10 only working on Windows 10 if the application is manifested correctly.  The method I used worked for me in a Rust program which is what I think matters the most in our context.  I will make a point of double checking that when I get back to my Windows system tomorrow.

In addition to my windows fix, we'll pick up various commits from `libssh2` master since the last time you updated your fork.

My plan is to replicate the same tagging arrangement you used for the last set of releases and then publish both of these to crates.io.
