### PR TITLE
Clarify docs of Session to refer to set_tcp_stream(), not handshake()

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -74,7 +74,7 @@ unsafe impl Send for SessionInner {}
 ///
 /// All other structures are based on an SSH session and cannot outlive a
 /// session. Sessions are created and then have the TCP socket handed to them
-/// (via the `handshake` method).
+/// (via the `set_tcp_stream` method).
 pub struct Session {
     inner: Rc<SessionInner>,
 }


### PR DESCRIPTION
The current docs still refer to passing a TcpStream via `handshake()`, which is no longer the case.