### PR TITLE
Make tests explain why they are failing

### DIFF
--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -12,11 +12,16 @@ mod knownhosts;
 mod session;
 mod sftp;
 
-pub fn socket() -> TcpStream {
+pub fn test_addr() -> String {
     let port = env::var("RUST_SSH2_FIXTURE_PORT")
         .map(|s| s.parse().unwrap())
         .unwrap_or(22);
-    TcpStream::connect(&format!("127.0.0.1:{}", port)).unwrap()
+    let addr = format!("127.0.0.1:{}", port);
+    addr
+}
+
+pub fn socket() -> TcpStream {
+    TcpStream::connect(&test_addr()).unwrap()
 }
 
 pub fn authed_session() -> ssh2::Session {

--- a/tests/all/session.rs
+++ b/tests/all/session.rs
@@ -57,7 +57,12 @@ fn keyboard_interactive() {
     sess.handshake().unwrap();
     sess.host_key().unwrap();
     let methods = sess.auth_methods(&user).unwrap();
-    assert!(methods.contains("keyboard-interactive"), "{}", methods);
+    assert!(
+        methods.contains("keyboard-interactive"),
+        "test server ({}) must support `ChallengeResponseAuthentication yes`, not just {}",
+        ::test_addr(),
+        methods
+    );
     assert!(!sess.authenticated());
 
     // We don't know the correct response for whatever challenges


### PR DESCRIPTION
The tests `assert!` a feature of the local ssh daemon which is disabled by default, at least from Ubuntu 18.04. Make the assertion error explain the problem, and hint how to fix it.