### PR TITLE
export block directions

### DIFF
--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -185,6 +185,9 @@ pub const LIBSSH2_CHANNEL_EXTENDED_DATA_NORMAL: c_int = 0;
 pub const LIBSSH2_CHANNEL_EXTENDED_DATA_IGNORE: c_int = 1;
 pub const LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE: c_int = 2;
 
+pub const LIBSSH2_SESSION_BLOCK_INBOUND: c_int = 1;
+pub const LIBSSH2_SESSION_BLOCK_OUTBOUND: c_int = 2;
+
 pub enum LIBSSH2_SESSION {}
 pub enum LIBSSH2_AGENT {}
 pub enum LIBSSH2_CHANNEL {}
@@ -362,6 +365,7 @@ extern "C" {
     );
     pub fn libssh2_keepalive_send(sess: *mut LIBSSH2_SESSION, seconds_to_next: *mut c_int)
         -> c_int;
+    pub fn libssh2_session_block_directions(sess: *mut LIBSSH2_SESSION) -> c_int;
 
     // agent
     pub fn libssh2_agent_init(sess: *mut LIBSSH2_SESSION) -> *mut LIBSSH2_AGENT;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub use error::Error;
 pub use knownhosts::{Host, Hosts, KnownHosts};
 pub use listener::Listener;
 use session::SessionInner;
-pub use session::{KeyboardInteractivePrompt, Prompt, ScpFileStat, Session, BlockDirections};
+pub use session::{BlockDirections, KeyboardInteractivePrompt, Prompt, ScpFileStat, Session};
 pub use sftp::{File, FileStat, FileType, OpenType};
 pub use sftp::{OpenFlags, RenameFlags, Sftp};
 pub use DisconnectCode::{AuthCancelledByUser, TooManyConnections};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub use error::Error;
 pub use knownhosts::{Host, Hosts, KnownHosts};
 pub use listener::Listener;
 use session::SessionInner;
-pub use session::{KeyboardInteractivePrompt, Prompt, ScpFileStat, Session};
+pub use session::{KeyboardInteractivePrompt, Prompt, ScpFileStat, Session, BlockDirections};
 pub use sftp::{File, FileStat, FileType, OpenType};
 pub use sftp::{OpenFlags, RenameFlags, Sftp};
 pub use DisconnectCode::{AuthCancelledByUser, TooManyConnections};

--- a/src/session.rs
+++ b/src/session.rs
@@ -937,8 +937,9 @@ impl Session {
         match dir {
             raw::LIBSSH2_SESSION_BLOCK_INBOUND => BlockDirections::Inbound,
             raw::LIBSSH2_SESSION_BLOCK_OUTBOUND => BlockDirections::Outbound,
-            x if x == raw::LIBSSH2_SESSION_BLOCK_INBOUND | raw::LIBSSH2_SESSION_BLOCK_OUTBOUND
-              => BlockDirections::Both,
+            x if x == raw::LIBSSH2_SESSION_BLOCK_INBOUND | raw::LIBSSH2_SESSION_BLOCK_OUTBOUND => {
+                BlockDirections::Both
+            }
             _ => BlockDirections::None,
         }
     }

--- a/tests/all/session.rs
+++ b/tests/all/session.rs
@@ -1,10 +1,10 @@
 use std::env;
 use std::fs::File;
-use std::io::prelude::*;
+use std::io::{self, prelude::*};
 use std::path::Path;
 use tempdir::TempDir;
 
-use ssh2::{HashType, KeyboardInteractivePrompt, MethodType, Prompt, Session};
+use ssh2::{HashType, KeyboardInteractivePrompt, MethodType, Prompt, Session, BlockDirections};
 
 #[test]
 fn session_is_send() {
@@ -176,4 +176,13 @@ fn scp_send() {
         .read_to_end(&mut actual)
         .unwrap();
     assert_eq!(actual, b"foobar");
+}
+
+#[test]
+fn block_directions() {
+    let mut sess = ::authed_session();
+    sess.set_blocking(false);
+    let actual = sess.handshake().map_err(|e| io::Error::from(e).kind());
+    assert_eq!(actual, Err(io::ErrorKind::WouldBlock));
+    assert_eq!(sess.block_directions(), BlockDirections::Inbound);
 }

--- a/tests/all/session.rs
+++ b/tests/all/session.rs
@@ -4,7 +4,7 @@ use std::io::{self, prelude::*};
 use std::path::Path;
 use tempdir::TempDir;
 
-use ssh2::{HashType, KeyboardInteractivePrompt, MethodType, Prompt, Session, BlockDirections};
+use ssh2::{BlockDirections, HashType, KeyboardInteractivePrompt, MethodType, Prompt, Session};
 
 #[test]
 fn session_is_send() {


### PR DESCRIPTION
Asynchronous clients need to know the blocking direction in order to wait on the correct events.