### PR TITLE
return correct errors

### DIFF
--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -136,7 +136,7 @@ impl Sftp {
                 open_type as c_int,
             );
             if ret.is_null() {
-                Err(self.last_session_error().unwrap_or_else(|| { Error::unknown() }))
+                Err(self.last_session_error().unwrap_or_else(Error::unknown))
             } else {
                 Ok(File::from_raw(self, ret))
             }

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -478,7 +478,7 @@ impl<'sftp> Read for File<'sftp> {
             let rc =
                 raw::libssh2_sftp_read(self.raw, buf.as_mut_ptr() as *mut _, buf.len() as size_t);
             match rc {
-                n if n < 0 =>  Err(Error::from_errno(n as _).into()),
+                n if n < 0 => Err(Error::from_errno(n as _).into()),
                 n => Ok(n as usize),
             }
         }

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -491,7 +491,7 @@ impl<'sftp> Write for File<'sftp> {
             raw::libssh2_sftp_write(self.raw, buf.as_ptr() as *const _, buf.len() as size_t)
         };
         if rc < 0 {
-            Err(Error::from_errno(rc as i32).into())
+            Err(Error::from_errno(rc as _).into())
         } else {
             Ok(rc as usize)
         }

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -359,8 +359,7 @@ impl Sftp {
         Error::from_errno(code as c_int)
     }
 
-    /// Peel off the last error to happen on this Session.
-    pub fn last_session_error(&self) -> Option<Error> {
+    fn last_session_error(&self) -> Option<Error> {
         Error::last_error_raw(self._sess.raw)
     }
 

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -478,7 +478,7 @@ impl<'sftp> Read for File<'sftp> {
             let rc =
                 raw::libssh2_sftp_read(self.raw, buf.as_mut_ptr() as *mut _, buf.len() as size_t);
             match rc {
-                n if n < 0 =>  Err(Error::from_errno(n as i32).into()),
+                n if n < 0 =>  Err(Error::from_errno(n as _).into()),
                 n => Ok(n as usize),
             }
         }


### PR DESCRIPTION
Seems like the errors that are returned here are not correct.

When I use the client in non blocking mode an unknown error is returned instead of would block.