### PR TITLE
fix: define libssh2_socket_t using pointer width for aarch64 windows

### DIFF
--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -296,9 +296,9 @@ pub struct LIBSSH2_USERAUTH_KBDINT_RESPONSE {
 
 #[cfg(unix)]
 pub type libssh2_socket_t = c_int;
-#[cfg(all(windows, target_arch = "x86"))]
+#[cfg(all(windows, target_pointer_width = "32"))]
 pub type libssh2_socket_t = u32;
-#[cfg(all(windows, target_arch = "x86_64"))]
+#[cfg(all(windows, target_pointer_width = "64"))]
 pub type libssh2_socket_t = u64;
 
 extern "C" {


### PR DESCRIPTION
This current library fails to compile on aarch64-pc-windows-msvc target. While normally having the if/else for target architecture be right, it looks like the windows `SOCKET` is simply an unsigned the size of a pointer (but `usize` fails as other code knows it's a `u32` or `u64` directly). This change defines it in terms of pointer width and allows the library (which is used by tons of other libraries and projects) to work on the Microsoft Surface Pro X (windows machine on aarch64) and thus allows more rust programs to natively run.