### PR TITLE
Make properly Send safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh2"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong.org>"]
 license = "MIT/Apache-2.0"
 keywords = ["ssh"]
@@ -20,6 +20,7 @@ vendored-openssl = ["libssh2-sys/vendored-openssl"]
 bitflags = "1.2"
 libc = "0.2"
 libssh2-sys = { path = "libssh2-sys", version = "0.2.13" }
+parking_lot = "0.10"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -14,6 +14,12 @@ pub struct Agent {
     sess: Arc<Mutex<SessionInner>>,
 }
 
+// Agent is both Send and Sync; the compiler can't see it because it
+// is pessimistic about the raw pointer.  We use Arc/Mutex to guard accessing
+// the raw pointer so we are safe for both.
+unsafe impl Send for Agent {}
+unsafe impl Sync for Agent {}
+
 /// A public key which is extracted from an SSH agent.
 #[derive(Debug, PartialEq, Eq)]
 pub struct PublicKey {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -14,6 +14,12 @@ struct ChannelInner {
     read_limit: Mutex<Option<u64>>,
 }
 
+// ChannelInner is both Send and Sync; the compiler can't see it because it
+// is pessimistic about the raw pointer.  We use Arc/Mutex to guard accessing
+// the raw pointer so we are safe for both.
+unsafe impl Send for ChannelInner {}
+unsafe impl Sync for ChannelInner {}
+
 struct LockedChannel<'a> {
     raw: *mut raw::LIBSSH2_CHANNEL,
     sess: MutexGuard<'a, SessionInner>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,7 @@
 //! agent.connect().unwrap();
 //! agent.list_identities().unwrap();
 //!
-//! for identity in agent.identities() {
-//!     let identity = identity.unwrap(); // assume no I/O errors
+//! for identity in agent.identities().unwrap() {
 //!     println!("{}", identity.comment());
 //!     let pubkey = identity.blob();
 //! }
@@ -138,13 +137,14 @@ extern crate libc;
 extern crate libssh2_sys as raw;
 #[macro_use]
 extern crate bitflags;
+extern crate parking_lot;
 
 use std::ffi::CStr;
 
-pub use agent::{Agent, Identities, PublicKey};
+pub use agent::{Agent, PublicKey};
 pub use channel::{Channel, ExitSignal, ReadWindow, Stream, WriteWindow};
 pub use error::Error;
-pub use knownhosts::{Host, Hosts, KnownHosts};
+pub use knownhosts::{Host, KnownHosts};
 pub use listener::Listener;
 use session::SessionInner;
 pub use session::{BlockDirections, KeyboardInteractivePrompt, Prompt, ScpFileStat, Session};

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,3 +1,4 @@
+use parking_lot::Mutex;
 use std::sync::Arc;
 use {raw, Channel, Error, SessionInner};
 
@@ -7,24 +8,27 @@ use {raw, Channel, Error, SessionInner};
 /// the remote server's port.
 pub struct Listener {
     raw: *mut raw::LIBSSH2_LISTENER,
-    sess: Arc<SessionInner>,
+    sess: Arc<Mutex<SessionInner>>,
 }
 
 impl Listener {
     /// Accept a queued connection from this listener.
     pub fn accept(&mut self) -> Result<Channel, Error> {
+        let sess = self.sess.lock();
         unsafe {
             let chan = raw::libssh2_channel_forward_accept(self.raw);
-            Channel::from_raw_opt(chan, &self.sess)
+            let err = sess.last_error();
+            Channel::from_raw_opt(chan, err, &self.sess)
         }
     }
 
     pub(crate) fn from_raw_opt(
         raw: *mut raw::LIBSSH2_LISTENER,
-        sess: &Arc<SessionInner>,
+        err: Option<Error>,
+        sess: &Arc<Mutex<SessionInner>>,
     ) -> Result<Self, Error> {
         if raw.is_null() {
-            Err(Error::last_error_raw(sess.raw).unwrap_or_else(Error::unknown))
+            Err(err.unwrap_or_else(Error::unknown))
         } else {
             Ok(Self {
                 raw,

--- a/src/session.rs
+++ b/src/session.rs
@@ -68,6 +68,11 @@ pub(crate) struct SessionInner {
     tcp: Option<TcpStream>,
 }
 
+// The compiler doesn't know that it is Send safe because of the raw
+// pointer inside.  We know that the way that it is used by libssh2
+// and this crate is Send safe.
+unsafe impl Send for SessionInner {}
+
 /// An SSH session, typically representing one TCP connection.
 ///
 /// All other structures are based on an SSH session and cannot outlive a

--- a/src/session.rs
+++ b/src/session.rs
@@ -78,6 +78,20 @@ unsafe impl Send for SessionInner {}
 /// All other structures are based on an SSH session and cannot outlive a
 /// session. Sessions are created and then have the TCP socket handed to them
 /// (via the `set_tcp_stream` method).
+///
+/// `Session`, and any objects its methods return, hold a reference to the underlying
+/// SSH session.  You may clone `Session` to obtain another handle referencing
+/// the same session, and create multiple `Channel` and `Stream` objects
+/// from that same underlying session, which can all be passed across thread
+/// boundaries (they are `Send` and `Sync`).  These are all related objects and
+/// are internally synchronized via a `Mutex` to make it safe to pass them
+/// around in this way.
+///
+/// This means that a blocking read from a `Channel` or `Stream` will block
+/// all other calls on objects created from the same underlying `Session`.
+/// If you need the ability to perform concurrent operations then you will
+/// need to create separate `Session` instances, or employ non-blocking mode,
+/// perhaps using the `async-ssh2` crate.
 #[derive(Clone)]
 pub struct Session {
     inner: Arc<Mutex<SessionInner>>,

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -14,6 +14,12 @@ struct SftpInner {
     sess: Arc<Mutex<SessionInner>>,
 }
 
+// Sftp is both Send and Sync; the compiler can't see it because it
+// is pessimistic about the raw pointer.  We use Arc/Mutex to guard accessing
+// the raw pointer so we are safe for both.
+unsafe impl Send for Sftp {}
+unsafe impl Sync for Sftp {}
+
 /// A handle to a remote filesystem over SFTP.
 ///
 /// Instances are created through the `sftp` method on a `Session`.
@@ -30,6 +36,12 @@ struct FileInner {
     raw: *mut raw::LIBSSH2_SFTP_HANDLE,
     sftp: Arc<SftpInner>,
 }
+
+// FileInner is both Send and Sync; the compiler can't see it because it
+// is pessimistic about the raw pointer.  We use Arc/Mutex to guard accessing
+// the raw pointer so we are safe for both.
+unsafe impl Send for FileInner {}
+unsafe impl Sync for FileInner {}
 
 struct LockedFile<'file> {
     sess: MutexGuard<'file, SessionInner>,

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -121,13 +121,6 @@ pub enum OpenType {
     Dir = raw::LIBSSH2_SFTP_OPENDIR as isize,
 }
 
-impl<'sftp> LockedSftp<'sftp> {
-    pub fn last_error(&self) -> Error {
-        let code = unsafe { raw::libssh2_sftp_last_error(self.raw) };
-        Error::from_errno(code as c_int)
-    }
-}
-
 impl Sftp {
     pub(crate) fn from_raw_opt(
         raw: *mut raw::LIBSSH2_SFTP,
@@ -167,7 +160,7 @@ impl Sftp {
                 open_type as c_int,
             );
             if ret.is_null() {
-                Err(locked.last_error())
+                Err(locked.sess.last_error().unwrap_or_else(Error::unknown))
             } else {
                 Ok(File::from_raw(self, ret))
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,14 +3,6 @@ use std::path::Path;
 
 use {raw, Error};
 
-#[doc(hidden)]
-pub trait Binding: Sized {
-    type Raw;
-
-    unsafe fn from_raw(raw: Self::Raw) -> Self;
-    fn raw(&self) -> Self::Raw;
-}
-
 #[cfg(unix)]
 pub fn path2bytes(p: &Path) -> Result<Cow<[u8]>, Error> {
     use std::ffi::OsStr;

--- a/tests/all/agent.rs
+++ b/tests/all/agent.rs
@@ -7,9 +7,8 @@ fn smoke() {
     agent.connect().unwrap();
     agent.list_identities().unwrap();
     {
-        let mut a = agent.identities();
-        let i1 = a.next().unwrap().unwrap();
-        a.count();
+        let a = agent.identities().unwrap();
+        let i1 = &a[0];
         assert!(agent.userauth("foo", &i1).is_err());
     }
     agent.disconnect().unwrap();

--- a/tests/all/channel.rs
+++ b/tests/all/channel.rs
@@ -24,6 +24,13 @@ fn consume_stdio(channel: &mut Channel) -> (String, String) {
 fn smoke() {
     let sess = ::authed_session();
     let mut channel = sess.channel_session().unwrap();
+
+    fn must_be_send<T: Send>(_: &T) -> bool {
+        true
+    }
+    assert!(must_be_send(&channel));
+    assert!(must_be_send(&channel.stream(0)));
+
     channel.flush().unwrap();
     channel.exec("true").unwrap();
     consume_stdio(&mut channel);

--- a/tests/all/knownhosts.rs
+++ b/tests/all/knownhosts.rs
@@ -3,8 +3,9 @@ use ssh2::{KnownHostFileKind, Session};
 #[test]
 fn smoke() {
     let sess = Session::new().unwrap();
-    let hosts = sess.known_hosts().unwrap();
-    assert_eq!(hosts.iter().count(), 0);
+    let known_hosts = sess.known_hosts().unwrap();
+    let hosts = known_hosts.hosts().unwrap();
+    assert_eq!(hosts.len(), 0);
 }
 
 #[test]
@@ -20,11 +21,14 @@ PW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi\
 /w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
 ";
     let sess = Session::new().unwrap();
-    let mut hosts = sess.known_hosts().unwrap();
-    hosts.read_str(encoded, KnownHostFileKind::OpenSSH).unwrap();
+    let mut known_hosts = sess.known_hosts().unwrap();
+    known_hosts
+        .read_str(encoded, KnownHostFileKind::OpenSSH)
+        .unwrap();
 
-    assert_eq!(hosts.iter().count(), 1);
-    let host = hosts.iter().next().unwrap().unwrap();
+    let hosts = known_hosts.hosts().unwrap();
+    assert_eq!(hosts.len(), 1);
+    let host = &hosts[0];
     assert_eq!(host.name(), None);
     assert_eq!(
         host.key(),
@@ -39,10 +43,10 @@ PW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi\
     );
 
     assert_eq!(
-        hosts
-            .write_string(&host, KnownHostFileKind::OpenSSH)
+        known_hosts
+            .write_string(host, KnownHostFileKind::OpenSSH)
             .unwrap(),
         encoded
     );
-    hosts.remove(host).unwrap();
+    known_hosts.remove(host).unwrap();
 }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -36,7 +36,8 @@ pub fn authed_session() -> ssh2::Session {
         let mut agent = sess.agent().unwrap();
         agent.connect().unwrap();
         agent.list_identities().unwrap();
-        let identity = agent.identities().next().unwrap().unwrap();
+        let identities = agent.identities().unwrap();
+        let identity = &identities[0];
         agent.userauth(&user, &identity).unwrap();
     }
     assert!(sess.authenticated());

--- a/tests/all/session.rs
+++ b/tests/all/session.rs
@@ -51,7 +51,7 @@ fn smoke_handshake() {
     agent.connect().unwrap();
     agent.list_identities().unwrap();
     {
-        let identity = agent.identities().next().unwrap().unwrap();
+        let identity = &agent.identities().unwrap()[0];
         agent.userauth(&user, &identity).unwrap();
     }
     assert!(sess.authenticated());


### PR DESCRIPTION
In earlier iterations I accidentally removed Send from Session and then
later restored it in an unsafe way.  This commit restructures the
bindings so that each of the objects holds a reference to the
appropriate thing to keep everything alive safely, without awkward
lifetimes to deal with.

The key to this is that the underlying Session is tracked by an
Arc<Mutex<>>, with the related objects ensuring that they lock this
before they call into the underlying API.

In order to make this work, I've had to adjust the API around iterating
both known hosts and agent identities: previously these would iterate
over internal references but with this shift there isn't a reasonable
way to make that safe.  The strategy is instead to return a copy of the
host/identity data and then later look up the associated raw pointer
when needed.  The purist in me feels that the copy feels slightly
wasteful, but the realist justifies this with the observation that the
cardinality of both known hosts and identities is typically small enough
that the cost of this is in the noise compared to actually doing the
crypto+network ops.

I've removed a couple of error code related helpers from some of
the objects: those were really internal APIs and were redundant
with methods exported by the Error type anyway.

Fixes: https://github.com/alexcrichton/ssh2-rs/issues/154
Refs: https://github.com/alexcrichton/ssh2-rs/issues/137