### PR TITLE
Precise error codes when using the SFTP subsystem

### DIFF
--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -350,6 +350,7 @@ extern "C" {
         method_type: c_int,
         algs: *mut *mut *const c_char,
     ) -> c_int;
+    pub fn libssh2_session_last_errno(sess: *mut LIBSSH2_SESSION) -> c_int;
     pub fn libssh2_session_last_error(
         sess: *mut LIBSSH2_SESSION,
         msg: *mut *mut c_char,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -4,7 +4,7 @@ use std::slice;
 use std::str;
 use std::sync::Arc;
 
-use {raw, Error, SessionInner};
+use {raw, Error, ErrorCode, SessionInner};
 
 /// A structure representing a connection to an SSH agent.
 ///
@@ -110,9 +110,12 @@ impl Agent {
     pub fn userauth(&self, username: &str, identity: &PublicKey) -> Result<(), Error> {
         let username = CString::new(username)?;
         let sess = self.sess.lock();
-        let raw_ident = self
-            .resolve_raw_identity(&sess, identity)?
-            .ok_or_else(|| Error::new(raw::LIBSSH2_ERROR_BAD_USE, "Identity not found in agent"))?;
+        let raw_ident = self.resolve_raw_identity(&sess, identity)?.ok_or_else(|| {
+            Error::new(
+                ErrorCode::Session(raw::LIBSSH2_ERROR_BAD_USE),
+                "Identity not found in agent",
+            )
+        })?;
         unsafe {
             sess.rc(raw::libssh2_agent_userauth(
                 self.raw,

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,17 +9,38 @@ use std::str;
 
 use {raw, Session};
 
+/// An error code originating from a particular source.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ErrorCode {
+    /// Codes for errors that originate in libssh2.
+    /// Can be one of  `LIBSSH2_ERROR_*` constants.
+    Session(libc::c_int),
+
+    /// Codes for errors that originate in the SFTP subsystem.
+    /// Can be one of `LIBSSH2_FX_*` constants.
+    //
+    // TODO: This should be `c_ulong` instead of `c_int` because these constants
+    // are only returned by `libssh2_sftp_last_error()` which returns `c_ulong`.
+    SFTP(libc::c_int),
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 /// Representation of an error that can occur within libssh2
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]
 pub struct Error {
-    code: libc::c_int,
+    code: ErrorCode,
     msg: Cow<'static, str>,
 }
 
 impl Error {
     #[doc(hidden)]
-    pub fn last_error_raw(raw: *mut raw::LIBSSH2_SESSION) -> Option<Error> {
+    pub fn last_session_error_raw(raw: *mut raw::LIBSSH2_SESSION) -> Option<Error> {
         unsafe {
             let mut msg = null_mut();
             let rc = raw::libssh2_session_last_error(raw, &mut msg, null_mut(), 0);
@@ -31,7 +52,7 @@ impl Error {
             // LIBSSH2_SESSION, so the error message should be copied before
             // it is overwritten by the next API call.
             Some(Self {
-                code: rc,
+                code: ErrorCode::Session(rc),
                 msg: make_error_message(msg),
             })
         }
@@ -53,14 +74,14 @@ impl Error {
             let mut msg = null_mut();
             let res = raw::libssh2_session_last_error(raw, &mut msg, null_mut(), 0);
             if res != rc {
-                return Self::from_errno(rc);
+                return Self::from_errno(ErrorCode::Session(rc));
             }
 
             // The pointer stored in `msg` points to the internal buffer of
             // LIBSSH2_SESSION, so the error message should be copied before
             // it is overwritten by the next API call.
             Self {
-                code: rc,
+                code: ErrorCode::Session(rc),
                 msg: make_error_message(msg),
             }
         }
@@ -69,106 +90,110 @@ impl Error {
     /// Generate the last error that occurred for a `Session`.
     ///
     /// Returns `None` if there was no last error.
-    pub fn last_error(sess: &Session) -> Option<Error> {
-        Self::last_error_raw(&mut *sess.raw())
+    pub fn last_session_error(sess: &Session) -> Option<Error> {
+        Self::last_session_error_raw(&mut *sess.raw())
     }
 
     /// Create a new error for the given code and message
-    pub fn new(code: libc::c_int, msg: &'static str) -> Error {
+    pub fn new(code: ErrorCode, msg: &'static str) -> Error {
         Error {
-            code: code,
+            code,
             msg: Cow::Borrowed(msg),
         }
     }
 
     /// Generate an error that represents EOF
     pub fn eof() -> Error {
-        Error::new(raw::LIBSSH2_ERROR_CHANNEL_EOF_SENT, "end of file")
+        Error::new(
+            ErrorCode::Session(raw::LIBSSH2_ERROR_CHANNEL_EOF_SENT),
+            "end of file",
+        )
     }
 
     /// Generate an error for unknown failure
     pub fn unknown() -> Error {
-        Error::new(libc::c_int::min_value(), "no other error listed")
-    }
-
-    pub(crate) fn rc(rc: libc::c_int) -> Result<(), Error> {
-        if rc == 0 {
-            Ok(())
-        } else {
-            Err(Self::from_errno(rc))
-        }
+        Error::new(
+            ErrorCode::Session(libc::c_int::min_value()),
+            "no other error listed",
+        )
     }
 
     /// Construct an error from an error code from libssh2
-    pub fn from_errno(code: libc::c_int) -> Error {
+    pub fn from_errno(code: ErrorCode) -> Error {
         let msg = match code {
-            raw::LIBSSH2_ERROR_BANNER_RECV => "banner recv failure",
-            raw::LIBSSH2_ERROR_BANNER_SEND => "banner send failure",
-            raw::LIBSSH2_ERROR_INVALID_MAC => "invalid mac",
-            raw::LIBSSH2_ERROR_KEX_FAILURE => "kex failure",
-            raw::LIBSSH2_ERROR_ALLOC => "alloc failure",
-            raw::LIBSSH2_ERROR_SOCKET_SEND => "socket send faiulre",
-            raw::LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE => "key exchange failure",
-            raw::LIBSSH2_ERROR_TIMEOUT => "timed out",
-            raw::LIBSSH2_ERROR_HOSTKEY_INIT => "hostkey init error",
-            raw::LIBSSH2_ERROR_HOSTKEY_SIGN => "hostkey sign error",
-            raw::LIBSSH2_ERROR_DECRYPT => "decrypt error",
-            raw::LIBSSH2_ERROR_SOCKET_DISCONNECT => "socket disconnected",
-            raw::LIBSSH2_ERROR_PROTO => "protocol error",
-            raw::LIBSSH2_ERROR_PASSWORD_EXPIRED => "password expired",
-            raw::LIBSSH2_ERROR_FILE => "file error",
-            raw::LIBSSH2_ERROR_METHOD_NONE => "bad method name",
-            raw::LIBSSH2_ERROR_AUTHENTICATION_FAILED => "authentication failed",
-            raw::LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED => "public key unverified",
-            raw::LIBSSH2_ERROR_CHANNEL_OUTOFORDER => "channel out of order",
-            raw::LIBSSH2_ERROR_CHANNEL_FAILURE => "channel failure",
-            raw::LIBSSH2_ERROR_CHANNEL_REQUEST_DENIED => "request denied",
-            raw::LIBSSH2_ERROR_CHANNEL_UNKNOWN => "unknown channel error",
-            raw::LIBSSH2_ERROR_CHANNEL_WINDOW_EXCEEDED => "window exceeded",
-            raw::LIBSSH2_ERROR_CHANNEL_PACKET_EXCEEDED => "packet exceeded",
-            raw::LIBSSH2_ERROR_CHANNEL_CLOSED => "closed channel",
-            raw::LIBSSH2_ERROR_CHANNEL_EOF_SENT => "eof sent",
-            raw::LIBSSH2_ERROR_SCP_PROTOCOL => "scp protocol error",
-            raw::LIBSSH2_ERROR_ZLIB => "zlib error",
-            raw::LIBSSH2_ERROR_SOCKET_TIMEOUT => "socket timeout",
-            raw::LIBSSH2_ERROR_SFTP_PROTOCOL => "sftp protocol error",
-            raw::LIBSSH2_ERROR_REQUEST_DENIED => "request denied",
-            raw::LIBSSH2_ERROR_METHOD_NOT_SUPPORTED => "method not supported",
-            raw::LIBSSH2_ERROR_INVAL => "invalid",
-            raw::LIBSSH2_ERROR_INVALID_POLL_TYPE => "invalid poll type",
-            raw::LIBSSH2_ERROR_PUBLICKEY_PROTOCOL => "public key protocol error",
-            raw::LIBSSH2_ERROR_EAGAIN => "operation would block",
-            raw::LIBSSH2_ERROR_BUFFER_TOO_SMALL => "buffer too small",
-            raw::LIBSSH2_ERROR_BAD_USE => "bad use error",
-            raw::LIBSSH2_ERROR_COMPRESS => "compression error",
-            raw::LIBSSH2_ERROR_OUT_OF_BOUNDARY => "out of bounds",
-            raw::LIBSSH2_ERROR_AGENT_PROTOCOL => "invalid agent protocol",
-            raw::LIBSSH2_ERROR_SOCKET_RECV => "error receiving on socket",
-            raw::LIBSSH2_ERROR_ENCRYPT => "bad encrypt",
-            raw::LIBSSH2_ERROR_BAD_SOCKET => "bad socket",
-            raw::LIBSSH2_ERROR_KNOWN_HOSTS => "known hosts error",
-            raw::LIBSSH2_FX_EOF => "end of file",
-            raw::LIBSSH2_FX_NO_SUCH_FILE => "no such file",
-            raw::LIBSSH2_FX_PERMISSION_DENIED => "permission denied",
-            raw::LIBSSH2_FX_FAILURE => "failure",
-            raw::LIBSSH2_FX_BAD_MESSAGE => "bad message",
-            raw::LIBSSH2_FX_NO_CONNECTION => "no connection",
-            raw::LIBSSH2_FX_CONNECTION_LOST => "connection lost",
-            raw::LIBSSH2_FX_OP_UNSUPPORTED => "operation unsupported",
-            raw::LIBSSH2_FX_INVALID_HANDLE => "invalid handle",
-            raw::LIBSSH2_FX_NO_SUCH_PATH => "no such path",
-            raw::LIBSSH2_FX_FILE_ALREADY_EXISTS => "file already exists",
-            raw::LIBSSH2_FX_WRITE_PROTECT => "file is write protected",
-            raw::LIBSSH2_FX_NO_MEDIA => "no media available",
-            raw::LIBSSH2_FX_NO_SPACE_ON_FILESYSTEM => "no space on filesystem",
-            raw::LIBSSH2_FX_QUOTA_EXCEEDED => "quota exceeded",
-            raw::LIBSSH2_FX_UNKNOWN_PRINCIPAL => "unknown principal",
-            raw::LIBSSH2_FX_LOCK_CONFLICT => "lock conflict",
-            raw::LIBSSH2_FX_DIR_NOT_EMPTY => "directory not empty",
-            raw::LIBSSH2_FX_NOT_A_DIRECTORY => "not a directory",
-            raw::LIBSSH2_FX_INVALID_FILENAME => "invalid filename",
-            raw::LIBSSH2_FX_LINK_LOOP => "link loop",
-            _ => "unknown error",
+            ErrorCode::Session(code) => match code {
+                raw::LIBSSH2_ERROR_BANNER_RECV => "banner recv failure",
+                raw::LIBSSH2_ERROR_BANNER_SEND => "banner send failure",
+                raw::LIBSSH2_ERROR_INVALID_MAC => "invalid mac",
+                raw::LIBSSH2_ERROR_KEX_FAILURE => "kex failure",
+                raw::LIBSSH2_ERROR_ALLOC => "alloc failure",
+                raw::LIBSSH2_ERROR_SOCKET_SEND => "socket send faiulre",
+                raw::LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE => "key exchange failure",
+                raw::LIBSSH2_ERROR_TIMEOUT => "timed out",
+                raw::LIBSSH2_ERROR_HOSTKEY_INIT => "hostkey init error",
+                raw::LIBSSH2_ERROR_HOSTKEY_SIGN => "hostkey sign error",
+                raw::LIBSSH2_ERROR_DECRYPT => "decrypt error",
+                raw::LIBSSH2_ERROR_SOCKET_DISCONNECT => "socket disconnected",
+                raw::LIBSSH2_ERROR_PROTO => "protocol error",
+                raw::LIBSSH2_ERROR_PASSWORD_EXPIRED => "password expired",
+                raw::LIBSSH2_ERROR_FILE => "file error",
+                raw::LIBSSH2_ERROR_METHOD_NONE => "bad method name",
+                raw::LIBSSH2_ERROR_AUTHENTICATION_FAILED => "authentication failed",
+                raw::LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED => "public key unverified",
+                raw::LIBSSH2_ERROR_CHANNEL_OUTOFORDER => "channel out of order",
+                raw::LIBSSH2_ERROR_CHANNEL_FAILURE => "channel failure",
+                raw::LIBSSH2_ERROR_CHANNEL_REQUEST_DENIED => "request denied",
+                raw::LIBSSH2_ERROR_CHANNEL_UNKNOWN => "unknown channel error",
+                raw::LIBSSH2_ERROR_CHANNEL_WINDOW_EXCEEDED => "window exceeded",
+                raw::LIBSSH2_ERROR_CHANNEL_PACKET_EXCEEDED => "packet exceeded",
+                raw::LIBSSH2_ERROR_CHANNEL_CLOSED => "closed channel",
+                raw::LIBSSH2_ERROR_CHANNEL_EOF_SENT => "eof sent",
+                raw::LIBSSH2_ERROR_SCP_PROTOCOL => "scp protocol error",
+                raw::LIBSSH2_ERROR_ZLIB => "zlib error",
+                raw::LIBSSH2_ERROR_SOCKET_TIMEOUT => "socket timeout",
+                raw::LIBSSH2_ERROR_SFTP_PROTOCOL => "sftp protocol error",
+                raw::LIBSSH2_ERROR_REQUEST_DENIED => "request denied",
+                raw::LIBSSH2_ERROR_METHOD_NOT_SUPPORTED => "method not supported",
+                raw::LIBSSH2_ERROR_INVAL => "invalid",
+                raw::LIBSSH2_ERROR_INVALID_POLL_TYPE => "invalid poll type",
+                raw::LIBSSH2_ERROR_PUBLICKEY_PROTOCOL => "public key protocol error",
+                raw::LIBSSH2_ERROR_EAGAIN => "operation would block",
+                raw::LIBSSH2_ERROR_BUFFER_TOO_SMALL => "buffer too small",
+                raw::LIBSSH2_ERROR_BAD_USE => "bad use error",
+                raw::LIBSSH2_ERROR_COMPRESS => "compression error",
+                raw::LIBSSH2_ERROR_OUT_OF_BOUNDARY => "out of bounds",
+                raw::LIBSSH2_ERROR_AGENT_PROTOCOL => "invalid agent protocol",
+                raw::LIBSSH2_ERROR_SOCKET_RECV => "error receiving on socket",
+                raw::LIBSSH2_ERROR_ENCRYPT => "bad encrypt",
+                raw::LIBSSH2_ERROR_BAD_SOCKET => "bad socket",
+                raw::LIBSSH2_ERROR_KNOWN_HOSTS => "known hosts error",
+                _ => "unknown SSH error",
+            },
+
+            ErrorCode::SFTP(code) => match code {
+                raw::LIBSSH2_FX_EOF => "end of file",
+                raw::LIBSSH2_FX_NO_SUCH_FILE => "no such file",
+                raw::LIBSSH2_FX_PERMISSION_DENIED => "permission denied",
+                raw::LIBSSH2_FX_FAILURE => "failure",
+                raw::LIBSSH2_FX_BAD_MESSAGE => "bad message",
+                raw::LIBSSH2_FX_NO_CONNECTION => "no connection",
+                raw::LIBSSH2_FX_CONNECTION_LOST => "connection lost",
+                raw::LIBSSH2_FX_OP_UNSUPPORTED => "operation unsupported",
+                raw::LIBSSH2_FX_INVALID_HANDLE => "invalid handle",
+                raw::LIBSSH2_FX_NO_SUCH_PATH => "no such path",
+                raw::LIBSSH2_FX_FILE_ALREADY_EXISTS => "file already exists",
+                raw::LIBSSH2_FX_WRITE_PROTECT => "file is write protected",
+                raw::LIBSSH2_FX_NO_MEDIA => "no media available",
+                raw::LIBSSH2_FX_NO_SPACE_ON_FILESYSTEM => "no space on filesystem",
+                raw::LIBSSH2_FX_QUOTA_EXCEEDED => "quota exceeded",
+                raw::LIBSSH2_FX_UNKNOWN_PRINCIPAL => "unknown principal",
+                raw::LIBSSH2_FX_LOCK_CONFLICT => "lock conflict",
+                raw::LIBSSH2_FX_DIR_NOT_EMPTY => "directory not empty",
+                raw::LIBSSH2_FX_NOT_A_DIRECTORY => "not a directory",
+                raw::LIBSSH2_FX_INVALID_FILENAME => "invalid filename",
+                raw::LIBSSH2_FX_LINK_LOOP => "link loop",
+                _ => "unknown SFTP error",
+            },
         };
         Error::new(code, msg)
     }
@@ -179,7 +204,7 @@ impl Error {
     }
 
     /// Return the code for this error
-    pub fn code(&self) -> libc::c_int {
+    pub fn code(&self) -> ErrorCode {
         self.code
     }
 }
@@ -187,8 +212,8 @@ impl Error {
 impl From<Error> for io::Error {
     fn from(err: Error) -> io::Error {
         let kind = match err.code {
-            raw::LIBSSH2_ERROR_EAGAIN => io::ErrorKind::WouldBlock,
-            raw::LIBSSH2_ERROR_TIMEOUT => io::ErrorKind::TimedOut,
+            ErrorCode::Session(raw::LIBSSH2_ERROR_EAGAIN) => io::ErrorKind::WouldBlock,
+            ErrorCode::Session(raw::LIBSSH2_ERROR_TIMEOUT) => io::ErrorKind::TimedOut,
             _ => io::ErrorKind::Other,
         };
         io::Error::new(kind, err.msg)
@@ -210,7 +235,7 @@ impl error::Error for Error {
 impl From<NulError> for Error {
     fn from(_: NulError) -> Error {
         Error::new(
-            raw::LIBSSH2_ERROR_INVAL,
+            ErrorCode::Session(raw::LIBSSH2_ERROR_INVAL),
             "provided data contained a nul byte and could not be used \
              as as string",
         )

--- a/src/knownhosts.rs
+++ b/src/knownhosts.rs
@@ -6,7 +6,7 @@ use std::str;
 use std::sync::Arc;
 
 use util;
-use {raw, CheckResult, Error, KnownHostFileKind, SessionInner};
+use {raw, CheckResult, Error, ErrorCode, KnownHostFileKind, SessionInner};
 
 /// A set of known hosts which can be used to verify the identity of a remote
 /// server.
@@ -113,7 +113,7 @@ impl KnownHosts {
         let sess = self.sess.lock();
         let raw_host = self.resolve_to_raw_host(&sess, host)?.ok_or_else(|| {
             Error::new(
-                raw::LIBSSH2_ERROR_BAD_USE,
+                ErrorCode::Session(raw::LIBSSH2_ERROR_BAD_USE),
                 "Host is not in the set of known hosts",
             )
         })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ use std::ffi::CStr;
 
 pub use agent::{Agent, PublicKey};
 pub use channel::{Channel, ExitSignal, ReadWindow, Stream, WriteWindow};
-pub use error::Error;
+pub use error::{Error, ErrorCode};
 pub use knownhosts::{Host, KnownHosts};
 pub use listener::Listener;
 use session::SessionInner;

--- a/src/session.rs
+++ b/src/session.rs
@@ -15,7 +15,7 @@ use std::str;
 use std::sync::Arc;
 
 use util;
-use {raw, ByApplication, DisconnectCode, Error, HostKeyType};
+use {raw, ByApplication, DisconnectCode, Error, ErrorCode, HostKeyType};
 use {Agent, Channel, HashType, KnownHosts, Listener, MethodType, Sftp};
 
 /// Called by libssh2 to respond to some number of challenges as part of
@@ -265,7 +265,7 @@ impl Session {
         unsafe {
             let stream = inner.tcp.as_ref().ok_or_else(|| {
                 Error::new(
-                    raw::LIBSSH2_ERROR_BAD_SOCKET,
+                    ErrorCode::Session(raw::LIBSSH2_ERROR_BAD_SOCKET),
                     "use set_tcp_stream() to associate with a TcpStream",
                 )
             })?;
@@ -447,7 +447,7 @@ impl Session {
             Some(identity) => identity,
             None => {
                 return Err(Error::new(
-                    raw::LIBSSH2_ERROR_INVAL as c_int,
+                    ErrorCode::Session(raw::LIBSSH2_ERROR_INVAL),
                     "no identities found in the ssh agent",
                 ))
             }
@@ -1037,7 +1037,7 @@ impl SessionInner {
     }
 
     pub fn last_error(&self) -> Option<Error> {
-        Error::last_error_raw(self.raw)
+        Error::last_session_error_raw(self.raw)
     }
 
     /// Set or clear blocking mode on session

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::path::Path;
 
-use {raw, Error};
+use {raw, Error, ErrorCode};
 
 #[cfg(unix)]
 pub fn path2bytes(p: &Path) -> Result<Cow<[u8]>, Error> {
@@ -16,7 +16,7 @@ pub fn path2bytes(p: &Path) -> Result<Cow<[u8]>, Error> {
         .map(|s| s.as_bytes())
         .ok_or_else(|| {
             Error::new(
-                raw::LIBSSH2_ERROR_INVAL,
+                ErrorCode::Session(raw::LIBSSH2_ERROR_INVAL),
                 "only unicode paths on windows may be used",
             )
         })
@@ -40,7 +40,7 @@ pub fn path2bytes(p: &Path) -> Result<Cow<[u8]>, Error> {
 fn check(b: Cow<[u8]>) -> Result<Cow<[u8]>, Error> {
     if b.iter().any(|b| *b == 0) {
         Err(Error::new(
-            raw::LIBSSH2_ERROR_INVAL,
+            ErrorCode::Session(raw::LIBSSH2_ERROR_INVAL),
             "path provided contains a 0 byte",
         ))
     } else {


### PR DESCRIPTION
When an error happens while using the SFTP subsystem, the error returned
by `libssh2` is `LIBSSH2_ERROR_SFTP_PROTOCOL`, which only indicates the
origin of the error, but not its nature. In order to know what caused
the error, `libssh2_sftp_last_error()` needs to be called, and would
return one of the `LIBSSH2_FX_*` error codes.

Previously, the `ssh2` crate didn't call `libssh2_sftp_last_error()` when
`LIBSSH2_ERROR_SFTP_PROTOCOL` was reported, but simply returned an obscure
`Error`. This is now fixed.

Fixes #182