### PR TITLE
libssh2-sys: Add support for zlib-ng

### DIFF
--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libssh2-sys"
-version = "0.2.18"
+version = "0.2.19"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong.org>"]
 links = "ssh2"
 build = "build.rs"
@@ -15,10 +15,11 @@ path = "lib.rs"
 
 [features]
 vendored-openssl = ["openssl-sys/vendored"]
+zlib-ng-compat = ["libz-sys/zlib-ng"]
 
 [dependencies]
-libz-sys = "1.0.21"
 libc = "0.2"
+libz-sys = { version = "1.1.0", default-features = false, features = ["libc"] }
 
 [target."cfg(unix)".dependencies]
 openssl-sys = "0.9.35"

--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -10,7 +10,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    if try_vcpkg() {
+    let zlib_ng_compat = env::var("CARGO_FEATURE_ZLIB_NG_COMPAT").is_ok();
+
+    if !zlib_ng_compat && try_vcpkg() {
         return;
     }
 
@@ -19,6 +21,9 @@ fn main() {
     // See https://github.com/alexcrichton/ssh2-rs/pull/88
     println!("cargo:rerun-if-env-changed=LIBSSH2_SYS_USE_PKG_CONFIG");
     if env::var("LIBSSH2_SYS_USE_PKG_CONFIG").is_ok() {
+        if zlib_ng_compat {
+            panic!("LIBSSH2_SYS_USE_PKG_CONFIG set, but cannot use zlib-ng-compat with system libssh2");
+        }
         if let Ok(lib) = pkg_config::find_library("libssh2") {
             for path in &lib.include_paths {
                 println!("cargo:include={}", path.display());


### PR DESCRIPTION
Update to libz-sys 1.1.0, which supports zlib-ng. Provide a feature
zlib-ng-compat to allow building with zlib-ng. Since doing so statically
links zlib-ng, ensure that this feature prevents using a system libssh2.