### PR TITLE
Update libssh2 submodule to track back from https://github.com/libssh2/libssh2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "libssh2-sys/libssh2"]
 	path = libssh2-sys/libssh2
-	url = https://github.com/wez/libssh2
-	branch = pr484
+	url = https://github.com/libssh2/libssh2
+	branch = master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ssh2"
 version = "0.9.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong.org>"]
+authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong.org>", "Matteo Bigoi <bigo@crisidev.org>"]
 license = "MIT/Apache-2.0"
 keywords = ["ssh"]
 readme = "README.md"
@@ -19,7 +19,7 @@ vendored-openssl = ["libssh2-sys/vendored-openssl"]
 [dependencies]
 bitflags = "1.2"
 libc = "0.2"
-libssh2-sys = { path = "libssh2-sys", version = "0.2.19" }
+libssh2-sys = { path = "libssh2-sys", version = "0.2.20" }
 parking_lot = "0.10"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ssh2-rs
 
-[![Build Status](https://travis-ci.com/alexcrichton/ssh2-rs.svg?branch=master)](https://travis-ci.com/alexcrichton/ssh2-rs)
 [![Build Status](https://github.com/alexcrichton/ssh2-rs/workflows/linux/badge.svg)](https://github.com/alexcrichton/ssh2-rs/actions?workflow=linux)
 [![Build Status](https://github.com/alexcrichton/ssh2-rs/workflows/Windows/badge.svg)](https://github.com/alexcrichton/ssh2-rs/actions?workflow=Windows)
 [![Build Status](https://github.com/alexcrichton/ssh2-rs/workflows/macOS/badge.svg)](https://github.com/alexcrichton/ssh2-rs/actions?workflow=macOS)
@@ -14,7 +13,7 @@ Rust bindings to libssh2, an ssh client library.
 ```toml
 # Cargo.toml
 [dependencies]
-ssh2 = "0.8"
+ssh2 = "0.9"
 ```
 
 ## Building on OSX 10.10+

--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libssh2-sys"
-version = "0.2.19"
-authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong.org>"]
+version = "0.2.20"
+authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong.org>", "Matteo Bigoi <bigo@crisidev.org>"]
 links = "ssh2"
 build = "build.rs"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This is the first time I do this, so I may be missing something..

1) Switched the gitmodule to https://github.com/libssh2/libssh2
2) Update libssh2-sys Cargo.toml version to 0.2.20
3) Update ssh2-rs Cargo.toml dep on sys crate to 0.2.20

Am I missing anything? The integration testing are running fine, so it "should" be good.