### PR TITLE
Update libssh2-sys to 0.2.21 in ssh2 dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ vendored-openssl = ["libssh2-sys/vendored-openssl"]
 bitflags = "1.2"
 libc = "0.2"
 libssh2-sys = { path = "libssh2-sys", version = "0.2.21" }
-parking_lot = "0.10"
+parking_lot = "0.11"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ vendored-openssl = ["libssh2-sys/vendored-openssl"]
 [dependencies]
 bitflags = "1.2"
 libc = "0.2"
-libssh2-sys = { path = "libssh2-sys", version = "0.2.20" }
+libssh2-sys = { path = "libssh2-sys", version = "0.2.21" }
 parking_lot = "0.10"
 
 [dev-dependencies]


### PR DESCRIPTION
I observed a build fail with ssh2 0.9.1 (cloud-hypervisor/rust-hypervisor-firmware#90). It seems to be because the libssh2-sys version is not updated from 0.2.20 on the ssh2 0.9.1 release.