### PR TITLE
Expose more SFTP file types

### DIFF
--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -177,9 +177,13 @@ pub const LIBSSH2_SFTP_RENAME_NATIVE: c_long = 0x4;
 pub const LIBSSH2_INIT_NO_CRYPTO: c_int = 0x1;
 
 pub const LIBSSH2_SFTP_S_IFMT: c_ulong = 0o170000;
+pub const LIBSSH2_SFTP_S_IFIFO: c_ulong = 0o010000;
+pub const LIBSSH2_SFTP_S_IFCHR: c_ulong = 0o020000;
 pub const LIBSSH2_SFTP_S_IFDIR: c_ulong = 0o040000;
+pub const LIBSSH2_SFTP_S_IFBLK: c_ulong = 0o060000;
 pub const LIBSSH2_SFTP_S_IFREG: c_ulong = 0o100000;
 pub const LIBSSH2_SFTP_S_IFLNK: c_ulong = 0o120000;
+pub const LIBSSH2_SFTP_S_IFSOCK: c_ulong = 0o140000;
 
 pub const LIBSSH2_CHANNEL_EXTENDED_DATA_NORMAL: c_int = 0;
 pub const LIBSSH2_CHANNEL_EXTENDED_DATA_IGNORE: c_int = 1;


### PR DESCRIPTION
As a user of the `ssh2` crate it was not possible to figure out if a
file was a named pipe, a character device, a block device, or a socket.

By changing FileType to an enum we expose more information about the
file type when it's available.

I tried to keep the API as backwards compatible as I could. Not all bit
patterns of `perm` lead to a valid/known filetype, so we end up with an
`Other` variant. Another design would have been to make
`FileStat::file_type` return an `Option<FileType>` but that would have
been a breaking API change.