### PR TITLE
Add tcp_stream() function to obtain raw fd/socket

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -323,6 +323,18 @@ impl Session {
         let _ = inner.tcp.replace(Box::new(stream));
     }
 
+    /// Obtain the raw fd from the session
+    #[cfg(unix)]
+    pub fn tcp_stream(&self) -> RawFd {
+        self.as_raw_fd()
+    }
+
+    /// Obtain the raw socket from the session
+    #[cfg(windows)]
+    pub fn tcp_stream(&self) -> RawSocket {
+        self.as_raw_socket()
+    }
+
     /// Attempt basic password authentication.
     ///
     /// Note that many SSH servers which appear to support ordinary password


### PR DESCRIPTION
This adds the convenient methods to obtain the raw file descriptor (Unix) or socket (Windows) which can be used lifted to the TcpStream which in turn can be used to get some useful information.

This method [was mentioned in the documentation](https://github.com/olksdr/ssh2-rs/blob/124a367fff514875eca9e1b876b7476d31272984/src/session.rs#L303) to `set_tcp_stream()` but was not provided at this moment. It must be fixed now.