### PR TITLE
Add `openssl-on-win32` feature that compiles against openssl on windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,4 +35,5 @@ jobs:
         cargo -V
         cargo test --no-run --target %TARGET%
         cargo run --manifest-path systest/Cargo.toml --target %TARGET%
+        cargo test --no-run --target %TARGET% --features openssl-on-win32,vendored-openssl
       shell: cmd

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ commands, forwarding local ports, etc.
 
 [features]
 vendored-openssl = ["libssh2-sys/vendored-openssl"]
+openssl-on-win32 = ["libssh2-sys/openssl-on-win32"]
 
 [dependencies]
 bitflags = "1.2"

--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -16,6 +16,7 @@ path = "lib.rs"
 [features]
 vendored-openssl = ["openssl-sys/vendored"]
 zlib-ng-compat = ["libz-sys/zlib-ng"]
+openssl-on-win32 = ["openssl-sys"]
 
 [dependencies]
 libc = "0.2"
@@ -23,6 +24,9 @@ libz-sys = { version = "1.1.0", default-features = false, features = ["libc"] }
 
 [target."cfg(unix)".dependencies]
 openssl-sys = "0.9.35"
+
+[target."cfg(windows)".dependencies]
+openssl-sys = { version="0.9.35", optional = true }
 
 [build-dependencies]
 pkg-config = "0.3.11"


### PR DESCRIPTION
I found that the non-openssl flavor of the build has a few gotchas around compatibility with various key formats, so I've been running with this change in wezterm for a little while.

I'd suggest pairing this feature with `openssl/vendored` in the embedding application.