### PR TITLE
Revert "Add documentation on where to find async compatible versions…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,6 @@
 //! Note that libssh2 only supports SSH *clients*, not SSH *servers*.
 //! Additionally it only supports protocol v2, not protocol v1.
 //!
-//! In case you are searching for an async versions of this library,
-//! you can look at https://github.com/spebern/async-ssh2 or https://github.com/bk-rs/async-ssh2-lite,
-//! which are both adding async compatibility on top of ssh2-rs implementation.
-//!
 //! # Examples
 //!
 //! ## Inspecting ssh-agent


### PR DESCRIPTION
… of ssh2-rs"

This reverts commit 0d316d2f734a4ee03523f6001f5a1a4bb7535bc9.

# Background
Documentation recommending async wrappers of `ssh2` was merged in back in Nov. 2020 in #204 to address questions regarding async compatibility in #58.

# Current Advice May Mislead Users
As of this commit, https://crates.io/crates/async-ssh2/0.1.2-beta is
listed as deprecated on crates.io.

I believe that the other alternative mentioned in the reverted commit,
async-ssh2-lite, has at least two serious correctness issues and should
not be recommended:

1. https://github.com/bk-rs/async-ssh2-lite/issues/9
2. https://github.com/bk-rs/async-ssh2-lite/issues/10

async-ssh2-lite is also lacking documentation and has no unit or
integration tests to give confidence in its implementation.

In my opinion, until such issues are resolved ssh2 should refrain from
recommending either of these crates to avoid misleading users into
believing that these implementations are tested and ready for
production.

# Next Steps
I believe we should immediately remove the current async advice from the `ssh2` documentation to avoid misleading users into thinking the async crate recommendations are of similar quality to `ssh2`. One is deprecated and the other has correctness bugs and poor documentation.

After that, it is worth considering adding new information about how users can write an async wrapper for whatever IO framework they are using.

Longer term, I'm interested in writing a tested and correct Tokio 1.0 compatible async layer over `ssh2`.  @crisidev Is this something you and the other maintainers would be interested in merging into `ssh2`? Would the answer change if it is possible to make it framework agnostic by abstracting the runtime with a trait?

Thanks for your consideration :)