### PR TITLE
`libssh2-sys`: use `src` instead `.git` as vendored indicator

### DIFF
--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -32,7 +32,7 @@ fn main() {
         }
     }
 
-    if !Path::new("libssh2/.git").exists() {
+    if !Path::new("libssh2/src").exists() {
         let _ = Command::new("git")
             .args(&["submodule", "update", "--init"])
             .status();


### PR DESCRIPTION
When someone vendored `libssh-sys` he may exclude `.git` folder.

When such things happened an attempt to build it may lead to error like: `fatal: not a git repository (or any of the parent directories): .git`.