### PR TITLE
Haiku: always link against shared library when cross-compiling

### DIFF
--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -32,13 +32,21 @@ fn main() {
         }
     }
 
+    // When cross-compiling for the Haiku platform, always link to
+    // the system-provided library.
+    let host = env::var("HOST").unwrap();
+    let target = env::var("TARGET").unwrap();
+
+    if host != target && target.contains("haiku") {
+        return println!("cargo:rustc-link-lib=ssh2");
+    }
+
     if !Path::new("libssh2/.git").exists() {
         let _ = Command::new("git")
             .args(&["submodule", "update", "--init"])
             .status();
     }
 
-    let target = env::var("TARGET").unwrap();
     let profile = env::var("PROFILE").unwrap();
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let mut cfg = cc::Build::new();


### PR DESCRIPTION
This is a niche change for the particular scenario where libssh2-sys is built as part of the rustc/cargo build. Due to various reasons, this is done with a cross-compiler. When cargo is built as part of the extended build, it also links against the curl shared library, which on Haiku links against libssh2.so. When libssh2-sys includes a static instance of all the symbols, this leads to a linker error because libcurl.so points to hidden symbols.

This change in the build-script short-circuits this problem by always falling back on the system library, specifically for the case when cross-compiling. Similar fixes have been done in [curl-sys](https://github.com/alexcrichton/curl-rust/blob/b3a3ce876921f2e82a145d9abd539cd8f9b7ab7b/curl-sys/build.rs#L22) and [libz-sys](https://github.com/rust-lang/libz-sys/blob/6b12e9a37bae1a444aaa1a11248c5b0e555869b4/build.rs#L58).