### PR TITLE
Ci runner version update

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.14]
+        os: [macos-11]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019]
+        os: [windows-2016, windows-2019, windows-2022]
         env:
         - TARGET: x86_64-pc-windows-msvc
         - TARGET: i686-pc-windows-msvc


### PR DESCRIPTION
- macOS 10.14 support has been dropped, and 10.15 is inanimately being unsupported https://github.com/actions/virtual-environments/issues/5583
- Windows 2022 is now out of beta