### PR TITLE
Update libssh2 submodule to include support RFC 8332

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh2"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong.org>", "Matteo Bigoi <bigo@crisidev.org>"]
 license = "MIT/Apache-2.0"
 keywords = ["ssh"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ openssl-on-win32 = ["libssh2-sys/openssl-on-win32"]
 [dependencies]
 bitflags = "1.2"
 libc = "0.2"
-libssh2-sys = { path = "libssh2-sys", version = "0.2.23" }
+libssh2-sys = { path = "libssh2-sys", version = "0.3.0" }
 parking_lot = "0.11"
 
 [dev-dependencies]

--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong.org>", "Matteo Bigoi <bigo@crisidev.org>"]
 links = "ssh2"
 build = "build.rs"

--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -84,6 +84,7 @@ fn main() {
         .file("libssh2/src/sftp.c")
         .file("libssh2/src/transport.c")
         .file("libssh2/src/userauth.c")
+        .file("libssh2/src/userauth_kbd_packet.c")
         .include(&include)
         .include("libssh2/src");
 

--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -98,6 +98,9 @@ pub const LIBSSH2_ERROR_SOCKET_RECV: c_int = -43;
 pub const LIBSSH2_ERROR_ENCRYPT: c_int = -44;
 pub const LIBSSH2_ERROR_BAD_SOCKET: c_int = -45;
 pub const LIBSSH2_ERROR_KNOWN_HOSTS: c_int = -46;
+pub const LIBSSH2_ERROR_CHANNEL_WINDOW_FULL: c_int = -47;
+pub const LIBSSH2_ERROR_KEYFILE_AUTH_FAILED: c_int = -48;
+pub const LIBSSH2_ERROR_RANDGEN: c_int = -49;
 
 pub const LIBSSH2_FX_EOF: c_int = 1;
 pub const LIBSSH2_FX_NO_SUCH_FILE: c_int = 2;

--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -302,8 +302,8 @@ pub type LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC = extern "C" fn(
 
 #[repr(C)]
 pub struct LIBSSH2_USERAUTH_KBDINT_PROMPT {
-    pub text: *mut c_char,
-    pub length: c_uint,
+    pub text: *mut c_uchar,
+    pub length: size_t,
     pub echo: c_uchar,
 }
 

--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -101,6 +101,7 @@ pub const LIBSSH2_ERROR_KNOWN_HOSTS: c_int = -46;
 pub const LIBSSH2_ERROR_CHANNEL_WINDOW_FULL: c_int = -47;
 pub const LIBSSH2_ERROR_KEYFILE_AUTH_FAILED: c_int = -48;
 pub const LIBSSH2_ERROR_RANDGEN: c_int = -49;
+pub const LIBSSH2_ERROR_MISSING_USERAUTH_BANNER: c_int = -50;
 
 pub const LIBSSH2_FX_EOF: c_int = 1;
 pub const LIBSSH2_FX_NO_SUCH_FILE: c_int = 2;
@@ -511,6 +512,7 @@ extern "C" {
     pub fn libssh2_channel_request_auth_agent(channel: *mut LIBSSH2_CHANNEL) -> c_int;
 
     // userauth
+    pub fn libssh2_userauth_banner(sess: *mut LIBSSH2_SESSION, banner: *mut *mut c_char) -> c_int;
     pub fn libssh2_userauth_authenticated(sess: *mut LIBSSH2_SESSION) -> c_int;
     pub fn libssh2_userauth_list(
         sess: *mut LIBSSH2_SESSION,

--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -48,6 +48,7 @@ pub const LIBSSH2_METHOD_COMP_CS: c_int = 6;
 pub const LIBSSH2_METHOD_COMP_SC: c_int = 7;
 pub const LIBSSH2_METHOD_LANG_CS: c_int = 8;
 pub const LIBSSH2_METHOD_LANG_SC: c_int = 9;
+pub const LIBSSH2_METHOD_SIGN_ALGO: c_int = 10;
 
 pub const LIBSSH2_CHANNEL_PACKET_DEFAULT: c_uint = 32768;
 pub const LIBSSH2_CHANNEL_WINDOW_DEFAULT: c_uint = 2 * 1024 * 1024;
@@ -102,6 +103,7 @@ pub const LIBSSH2_ERROR_CHANNEL_WINDOW_FULL: c_int = -47;
 pub const LIBSSH2_ERROR_KEYFILE_AUTH_FAILED: c_int = -48;
 pub const LIBSSH2_ERROR_RANDGEN: c_int = -49;
 pub const LIBSSH2_ERROR_MISSING_USERAUTH_BANNER: c_int = -50;
+pub const LIBSSH2_ERROR_ALGO_UNSUPPORTED: c_int = -51;
 
 pub const LIBSSH2_FX_EOF: c_int = 1;
 pub const LIBSSH2_FX_NO_SUCH_FILE: c_int = 2;

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,7 +127,7 @@ impl Error {
                 raw::LIBSSH2_ERROR_INVALID_MAC => "invalid mac",
                 raw::LIBSSH2_ERROR_KEX_FAILURE => "kex failure",
                 raw::LIBSSH2_ERROR_ALLOC => "alloc failure",
-                raw::LIBSSH2_ERROR_SOCKET_SEND => "socket send faiulre",
+                raw::LIBSSH2_ERROR_SOCKET_SEND => "socket send failure",
                 raw::LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE => "key exchange failure",
                 raw::LIBSSH2_ERROR_TIMEOUT => "timed out",
                 raw::LIBSSH2_ERROR_HOSTKEY_INIT => "hostkey init error",

--- a/src/error.rs
+++ b/src/error.rs
@@ -171,6 +171,7 @@ impl Error {
                 raw::LIBSSH2_ERROR_KEYFILE_AUTH_FAILED => "keyfile auth failed",
                 raw::LIBSSH2_ERROR_RANDGEN => "unable to get random bytes",
                 raw::LIBSSH2_ERROR_MISSING_USERAUTH_BANNER => "missing userauth banner",
+                raw::LIBSSH2_ERROR_ALGO_UNSUPPORTED => "algorithm unsupported",
                 _ => "unknown error",
             },
             ErrorCode::SFTP(code) => match code {

--- a/src/error.rs
+++ b/src/error.rs
@@ -167,6 +167,9 @@ impl Error {
                 raw::LIBSSH2_ERROR_ENCRYPT => "bad encrypt",
                 raw::LIBSSH2_ERROR_BAD_SOCKET => "bad socket",
                 raw::LIBSSH2_ERROR_KNOWN_HOSTS => "known hosts error",
+                raw::LIBSSH2_ERROR_CHANNEL_WINDOW_FULL => "channel window full",
+                raw::LIBSSH2_ERROR_KEYFILE_AUTH_FAILED => "keyfile auth failed",
+                raw::LIBSSH2_ERROR_RANDGEN => "unable to get random bytes",
                 _ => "unknown error",
             },
             ErrorCode::SFTP(code) => match code {

--- a/src/error.rs
+++ b/src/error.rs
@@ -170,6 +170,7 @@ impl Error {
                 raw::LIBSSH2_ERROR_CHANNEL_WINDOW_FULL => "channel window full",
                 raw::LIBSSH2_ERROR_KEYFILE_AUTH_FAILED => "keyfile auth failed",
                 raw::LIBSSH2_ERROR_RANDGEN => "unable to get random bytes",
+                raw::LIBSSH2_ERROR_MISSING_USERAUTH_BANNER => "missing userauth banner",
                 _ => "unknown error",
             },
             ErrorCode::SFTP(code) => match code {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,7 @@ pub enum MethodType {
     CompSc = raw::LIBSSH2_METHOD_COMP_SC as isize,
     LangCs = raw::LIBSSH2_METHOD_LANG_CS as isize,
     LangSc = raw::LIBSSH2_METHOD_LANG_SC as isize,
+    SignAlgo = raw::LIBSSH2_METHOD_SIGN_ALGO as isize,
 }
 
 /// When passed to `Channel::flush_stream`, flushes all extended data


### PR DESCRIPTION
The main commit in question is [libssh2@64a555d](https://github.com/libssh2/libssh2/commit/64a555d), but follow-on commits add
relevant agent support and fix bugs.

Fixes #219