### PR TITLE
CI OS cleanup

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-20.04]
         rust_toolchain: [stable, beta]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11]
+        os: [macos-12, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019, windows-2022]
+        os: [windows-2019, windows-2022]
         env:
         - TARGET: x86_64-pc-windows-msvc
         - TARGET: i686-pc-windows-msvc


### PR DESCRIPTION
`windows-2016` is no longer supported so CI builds never finish. `ubuntu-18.04` is deprecated and will soon be in the same situation.

While in there `macos-12` and `ubuntu-22.04` were added.