### PR TITLE
Add Session.userauth_banner

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -648,6 +648,27 @@ impl Session {
         }
     }
 
+    /// Retrieve banner message from server, if available.
+    ///
+    /// When no such message is sent by server or if no authentication attempt has
+    /// been made, this function returns LIBSSH2_ERROR_MISSING_AUTH_BANNER.
+    ///
+    /// The return value is the userauth banner or None or an Error
+    pub fn userauth_banner(&self) -> Result<Option<&str>, Error> {
+        let mut userauth_banner = null_mut();
+        let inner = self.inner();
+        match unsafe { raw::libssh2_userauth_banner(inner.raw, &mut userauth_banner)} {
+            0 => {
+                unsafe {
+                    Ok(::opt_bytes(self, userauth_banner).and_then(|s| str::from_utf8(s).ok()))
+                }
+            },
+            rc => {
+                Err(Error::from_errno(ErrorCode::Session(rc)))
+            }
+        }
+    }
+
     /// Set preferred key exchange method
     ///
     /// The preferences provided are a comma delimited list of preferred methods

--- a/tests/all/session.rs
+++ b/tests/all/session.rs
@@ -59,6 +59,19 @@ fn smoke_handshake() {
 }
 
 #[test]
+fn smoke_userauth_banner() {
+    let user = env::var("USER").unwrap();
+    let socket = ::socket();
+    let mut sess = Session::new().unwrap();
+    sess.set_tcp_stream(socket);
+    sess.handshake().unwrap();
+    sess.host_key().unwrap();
+    sess.auth_methods(&user).unwrap();
+    let banner = sess.userauth_banner().unwrap().unwrap();
+    assert!(banner=="Authorized access only!");
+}
+
+#[test]
 fn keyboard_interactive() {
     let user = env::var("USER").unwrap();
     let socket = ::socket();

--- a/tests/banner
+++ b/tests/banner
@@ -1,0 +1,1 @@
+Authorized access only!

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -35,6 +35,7 @@ cat > $SSHDIR/sshd_config <<-EOT
 AuthorizedKeysFile=$SSHDIR/authorized_keys
 HostKey=$SSHDIR/ssh_host_rsa_key
 PidFile=$SSHDIR/sshd.pid
+Banner banner
 Subsystem sftp internal-sftp
 UsePAM yes
 X11Forwarding yes


### PR DESCRIPTION
Implements #275

Add a method retrieve the ssh userauth banner. Returns the SSH_MSG_USERAUTH_BANNER message sent by the server.
Will return `[Session(-50)] missing userauth banner` if user auth hasn't yet been attempted.

```rust
  let auth_methods = session.auth_methods(user)?;
  
  if let Some(ret) = session.userauth_banner()? {
      println!("{}", ret);
  };    
```

Example:
```
---------  AT&T IP Services Route Monitor  -----------

The information available through <snipped> is offered
by AT&T's Internet engineering organization to the Internet community.

This router maintains eBGP peerings with customer-facing routers
throughout the AT&T IP Services Backbone:
...
```