### PR TITLE
add Session::channel_direct_streamlocal

### DIFF
--- a/libssh2-sys/build.rs
+++ b/libssh2-sys/build.rs
@@ -69,6 +69,7 @@ fn main() {
         .file("libssh2/src/channel.c")
         .file("libssh2/src/comp.c")
         .file("libssh2/src/crypt.c")
+        .file("libssh2/src/crypto.c")
         .file("libssh2/src/global.c")
         .file("libssh2/src/hostkey.c")
         .file("libssh2/src/keepalive.c")
@@ -98,12 +99,10 @@ fn main() {
         if env::var_os("CARGO_FEATURE_OPENSSL_ON_WIN32").is_some() {
             cfg.define("LIBSSH2_OPENSSL", None);
             cfg.define("HAVE_EVP_AES_128_CTR", None);
-            cfg.file("libssh2/src/openssl.c");
             println!("cargo:rustc-link-lib=static=libssl");
             println!("cargo:rustc-link-lib=static=libcrypto");
         } else {
             cfg.define("LIBSSH2_WINCNG", None);
-            cfg.file("libssh2/src/wincng.c");
         }
     } else {
         cfg.flag("-fvisibility=hidden");
@@ -122,8 +121,6 @@ fn main() {
         cfg.define("HAVE_EVP_AES_128_CTR", None);
         cfg.define("HAVE_POLL", None);
         cfg.define("HAVE_GETTIMEOFDAY", None);
-
-        cfg.file("libssh2/src/openssl.c");
 
         // Create `libssh2_config.h`
         let config = fs::read_to_string("libssh2/src/libssh2_config_cmake.h.in").unwrap();

--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -498,6 +498,12 @@ extern "C" {
         shost: *const c_char,
         sport: c_int,
     ) -> *mut LIBSSH2_CHANNEL;
+    pub fn libssh2_channel_direct_streamlocal_ex(
+        ses: *mut LIBSSH2_SESSION,
+        socket_path: *const c_char,
+        shost: *const c_char,
+        sport: c_int,
+    ) -> *mut LIBSSH2_CHANNEL;
     pub fn libssh2_channel_forward_accept(listener: *mut LIBSSH2_LISTENER) -> *mut LIBSSH2_CHANNEL;
     pub fn libssh2_channel_forward_cancel(listener: *mut LIBSSH2_LISTENER) -> c_int;
     pub fn libssh2_channel_forward_listen_ex(


### PR DESCRIPTION
Support for this extension was officially added to libssh2 in v1.11.0 via https://github.com/libssh2/libssh2/pull/945.

This PR updates libssh2 to this new version and adds the bindings for `libssh2_channel_direct_streamlocal_ex`.

Closes #279

See https://github.com/libssh2/libssh2/commit/4f0f4bff5a92dce6a6cd7a5600a8ee5660402c3f for reference to explain the `build.rs` changes.

Test Plan:

https://gist.github.com/demosdemon/475db259ebf63cfb35cb1fb4186a67cd