### PR TITLE
Update dependency `bitflags` from v1 to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ vendored-openssl = ["libssh2-sys/vendored-openssl"]
 openssl-on-win32 = ["libssh2-sys/openssl-on-win32"]
 
 [dependencies]
-bitflags = "1.2"
+bitflags = "2"
 libc = "0.2"
 libssh2-sys = { path = "libssh2-sys", version = "0.3.0" }
 parking_lot = "0.12"

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,6 +23,7 @@ use {Agent, Channel, HashType, KnownHosts, Listener, MethodType, Sftp};
 bitflags! {
     /// Flags which can be used with the session trace method to set
     /// the trace level.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct TraceFlags: c_int {
         /// Authentication debugging
         const AUTH      = raw::LIBSSH2_TRACE_AUTH;

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -106,6 +106,7 @@ pub enum FileType {
 
 bitflags! {
     /// Options that can be used to configure how a file is opened
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct OpenFlags: c_ulong {
         /// Open the file for reading.
         const READ = raw::LIBSSH2_FXF_READ;
@@ -121,15 +122,16 @@ bitflags! {
         /// Forces an existing file with the same name to be truncated to zero
         /// length when creating a file by specifying `Create`. Using this flag
         /// implies the `Create` flag.
-        const TRUNCATE = raw::LIBSSH2_FXF_TRUNC | Self::CREATE.bits;
+        const TRUNCATE = raw::LIBSSH2_FXF_TRUNC | Self::CREATE.bits();
         /// Causes the request to fail if the named file already exists. Using
         /// this flag implies the `Create` flag.
-        const EXCLUSIVE = raw::LIBSSH2_FXF_EXCL | Self::CREATE.bits;
+        const EXCLUSIVE = raw::LIBSSH2_FXF_EXCL | Self::CREATE.bits();
     }
 }
 
 bitflags! {
     /// Options to `Sftp::rename`.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct RenameFlags: c_long {
         /// In a rename operation, overwrite the destination if it already
         /// exists. If this flag is not present then it is an error if the


### PR DESCRIPTION
This change updates `bitflags` from v1
to [v2][bitflags-2].

`bitflags` v2 no longer implements
`PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash`,
`Debug`, `Clone` and `Copy` for generated structs
by default.

For backwards compatibility of `EventMask` and
`WatchMask` (both part of the public API)
these standard traits are deliberately derived,
in line with the rust library
[API guidelines][api-guidelines].

[bitflags-2]: https://github.com/bitflags/bitflags/releases/tag/2.0.0
[api-guidelines]: https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits

Implements #307.