### PR TITLE
Implement `Clone` for `Channel` and `Stream`

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -76,6 +76,13 @@ impl Channel {
 
 /// A channel can have a number of streams, each identified by an id, each of
 /// which implements the `Read` and `Write` traits.
+///
+/// You may clone a `Stream` to obtain another handle to the same underlying
+/// stream, but note that all clones will share the same underlying SSH
+/// session and will be subject to the same blocking behavior. For more details
+/// on the implications of cloning and blocking operations, refer to the
+/// `Session` documentation.
+#[derive(Clone)]
 pub struct Stream {
     channel_inner: Arc<ChannelInner>,
     id: i32,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -35,6 +35,13 @@ struct LockedChannel<'a> {
 /// implements the `Reader` and `Writer` traits to send and receive data.
 /// Whether or not I/O operations are blocking is mandated by the `blocking`
 /// flag on a channel's corresponding `Session`.
+///
+/// You may clone a `Channel` to obtain another handle to the same underlying
+/// channel, but note that all clones will share the same underlying SSH
+/// session and will be subject to the same blocking behavior. For more details
+/// on the implications of cloning and blocking operations, refer to the
+/// `Session` documentation.
+#[derive(Clone)]
 pub struct Channel {
     channel_inner: Arc<ChannelInner>,
 }


### PR DESCRIPTION
Based on the prior discussion in https://github.com/alexcrichton/ssh2-rs/issues/158 I would like to propose implementing `Clone` for additional interior locked structures to further improve ergonomics.

I extended their documentation accordingly to align with the behavior described by `Session`.