### PR TITLE
Fix typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ pub enum HostKeyType {
     Ecdsa256 = raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_256 as isize,
     Ecdsa384 = raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_384 as isize,
     Ecdsa521 = raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_521 as isize,
-    Ed255219 = raw::LIBSSH2_HOSTKEY_TYPE_ED25519 as isize,
+    Ed25519 = raw::LIBSSH2_HOSTKEY_TYPE_ED25519 as isize,
 }
 
 #[allow(missing_docs)]
@@ -356,7 +356,7 @@ pub enum KnownHostKeyFormat {
     Ecdsa256 = raw::LIBSSH2_KNOWNHOST_KEY_ECDSA_256 as isize,
     Ecdsa384 = raw::LIBSSH2_KNOWNHOST_KEY_ECDSA_384 as isize,
     Ecdsa521 = raw::LIBSSH2_KNOWNHOST_KEY_ECDSA_521 as isize,
-    Ed255219 = raw::LIBSSH2_KNOWNHOST_KEY_ED25519 as isize,
+    Ed25519 = raw::LIBSSH2_KNOWNHOST_KEY_ED25519 as isize,
 }
 
 impl From<HostKeyType> for KnownHostKeyFormat {
@@ -368,7 +368,7 @@ impl From<HostKeyType> for KnownHostKeyFormat {
             HostKeyType::Ecdsa256 => KnownHostKeyFormat::Ecdsa256,
             HostKeyType::Ecdsa384 => KnownHostKeyFormat::Ecdsa384,
             HostKeyType::Ecdsa521 => KnownHostKeyFormat::Ecdsa521,
-            HostKeyType::Ed255219 => KnownHostKeyFormat::Ed255219,
+            HostKeyType::Ed25519 => KnownHostKeyFormat::Ed25519,
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -978,7 +978,7 @@ impl Session {
                 raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_256 => HostKeyType::Ecdsa256,
                 raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_384 => HostKeyType::Ecdsa384,
                 raw::LIBSSH2_HOSTKEY_TYPE_ECDSA_521 => HostKeyType::Ecdsa521,
-                raw::LIBSSH2_HOSTKEY_TYPE_ED25519 => HostKeyType::Ed255219,
+                raw::LIBSSH2_HOSTKEY_TYPE_ED25519 => HostKeyType::Ed25519,
                 raw::LIBSSH2_HOSTKEY_TYPE_UNKNOWN => HostKeyType::Unknown,
                 _ => HostKeyType::Unknown,
             };


### PR DESCRIPTION
Fixes a typo in the Ed25519 Key name.

Also i wanted to ask if there is a plan to do a release anytime soon? If this is a more complex topic i can make a separate issue to discuss it.