### PR TITLE
interactive-keyboard-null-ptr-handling

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -396,8 +396,13 @@ impl Session {
                     slice::from_raw_parts(instruction as *const u8, instruction_len as usize)
                 };
                 let instruction = String::from_utf8_lossy(instruction);
-
+                if prompts.is_null() || num_prompts < 0 {
+                    return;
+                }
                 let prompts = unsafe { slice::from_raw_parts(prompts, num_prompts as usize) };
+                if responses.is_null() || num_prompts < 0 {
+                    return;
+                }
                 let responses =
                     unsafe { slice::from_raw_parts_mut(responses, num_prompts as usize) };
 


### PR DESCRIPTION
This hack seems to fix the behavior seen on ARM-based Mac's when a null pointer is provided from the underlying libssh2>
For reference:
https://github.com/alexcrichton/ssh2-rs/issues/326

I'm not confident this is the correct fix, but it does seem to allow sessions to be established in my test bed. I'd also assume that a holistic fix needs to be handled/provided within libssh2 to avoid this in the first place. 

Happy to revise/abandon based on feedback, not pretending to be an expert on ssh2/libssh2