### PR TITLE
Pass `comment` as `CString`

### DIFF
--- a/src/knownhosts.rs
+++ b/src/knownhosts.rs
@@ -273,7 +273,7 @@ impl KnownHosts {
                 key.as_ptr() as *mut _,
                 key.len() as size_t,
                 comment.as_ptr() as *const _,
-                comment.count_bytes() as size_t,
+                comment.as_bytes().len() as size_t,
                 flags,
                 null_mut(),
             );

--- a/src/knownhosts.rs
+++ b/src/knownhosts.rs
@@ -261,6 +261,7 @@ impl KnownHosts {
         fmt: ::KnownHostKeyFormat,
     ) -> Result<(), Error> {
         let host = CString::new(host)?;
+        let comment = CString::new(comment)?;
         let flags =
             raw::LIBSSH2_KNOWNHOST_TYPE_PLAIN | raw::LIBSSH2_KNOWNHOST_KEYENC_RAW | (fmt as c_int);
         let sess = self.sess.lock();
@@ -272,7 +273,7 @@ impl KnownHosts {
                 key.as_ptr() as *mut _,
                 key.len() as size_t,
                 comment.as_ptr() as *const _,
-                comment.len() as size_t,
+                comment.count_bytes() as size_t,
                 flags,
                 null_mut(),
             );


### PR DESCRIPTION
The `libssh2_knownhost_addc()` expects `comment` to be a C string: it copies `commentlen + 1` bytes internally from the buffer pointed by `comment` pointer. Granted, this is misleading: one would expect that if a function takes a pointer and length of data, it wouldn't access memory past this limit.

Passing a `&str` as a pointer and its length is incorrect and results in segmentation fault with `rustc` > 1.78.0 on macOS 14.6.1 (23G93) and FreeBSD 14 - we pass empty &str literal to the function.