### PR TITLE
ci: Remove MacOS 12 runner

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13, macos-14]
+        os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Of course only after doing a bunch of CI cleanup do I notice that MacOS 12 runners are being deprecated.