### PR TITLE
Add SSH agent set/get support

### DIFF
--- a/libssh2-sys/lib.rs
+++ b/libssh2-sys/lib.rs
@@ -404,6 +404,8 @@ extern "C" {
         username: *const c_char,
         identity: *mut libssh2_agent_publickey,
     ) -> c_int;
+    pub fn libssh2_agent_set_identity_path(agent: *mut LIBSSH2_AGENT, path: *const c_char);
+    pub fn libssh2_agent_get_identity_path(agent: *mut LIBSSH2_AGENT) -> *const c_char;
 
     // channels
     pub fn libssh2_channel_free(chan: *mut LIBSSH2_CHANNEL) -> c_int;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,10 +1,12 @@
 use parking_lot::{Mutex, MutexGuard};
 use std::ffi::{CStr, CString};
+use std::path::{Path, PathBuf};
 use std::ptr::null_mut;
 use std::slice;
 use std::str;
 use std::sync::Arc;
 
+use util;
 use {raw, Error, ErrorCode, SessionInner};
 
 /// A structure representing a connection to an SSH agent.
@@ -123,6 +125,27 @@ impl Agent {
                 username.as_ptr(),
                 raw_ident,
             ))
+        }
+    }
+
+    /// Set a custom agent socket path to connect to.
+    pub fn set_identity_path(&mut self, path: &Path) -> Result<(), Error> {
+        let path = CString::new(util::path2bytes(path)?)?;
+        unsafe {
+            raw::libssh2_agent_set_identity_path(self.raw, path.as_ptr());
+        }
+        Ok(())
+    }
+
+    /// Get the custom agent socket path, if set.
+    pub fn identity_path(&self) -> Option<PathBuf> {
+        unsafe {
+            let ptr = raw::libssh2_agent_get_identity_path(self.raw);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(util::mkpath(CStr::from_ptr(ptr).to_bytes()))
+            }
         }
     }
 }

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -388,7 +388,7 @@ impl Sftp {
         }
         Self::rc(&locked, rc).map(move |_| {
             unsafe { ret.set_len(rc as usize) }
-            mkpath(ret)
+            util::mkpath(&ret)
         })
     }
 
@@ -644,7 +644,7 @@ impl File {
                 unsafe {
                     buf.set_len(rc as usize);
                 }
-                (mkpath(buf), FileStat::from_raw(&stat))
+                (util::mkpath(&buf), FileStat::from_raw(&stat))
             })
         }
     }
@@ -906,16 +906,4 @@ impl FileType {
             other => FileType::Other(other),
         }
     }
-}
-
-#[cfg(unix)]
-fn mkpath(v: Vec<u8>) -> PathBuf {
-    use std::ffi::OsStr;
-    use std::os::unix::prelude::*;
-    PathBuf::from(OsStr::from_bytes(&v))
-}
-#[cfg(windows)]
-fn mkpath(v: Vec<u8>) -> PathBuf {
-    use std::str;
-    PathBuf::from(str::from_utf8(&v).unwrap())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use {raw, Error, ErrorCode};
 
@@ -35,6 +35,18 @@ pub fn path2bytes(p: &Path) -> Result<Cow<'_, [u8]>, Error> {
             }
         })
         .and_then(check)
+}
+
+#[cfg(unix)]
+pub fn mkpath(bytes: &[u8]) -> PathBuf {
+    use std::ffi::OsStr;
+    use std::os::unix::prelude::*;
+    PathBuf::from(OsStr::from_bytes(bytes))
+}
+#[cfg(windows)]
+pub fn mkpath(bytes: &[u8]) -> PathBuf {
+    use std::str;
+    PathBuf::from(str::from_utf8(bytes).unwrap())
 }
 
 fn check(b: Cow<[u8]>) -> Result<Cow<[u8]>, Error> {


### PR DESCRIPTION
libssh2 supports `libssh2_agent_set_identity_path` and `libssh2_agent_get_identity_path`, but ssh2-rs currently does not expose these - in practice this means that the `SSH_AUTH_SOCK` environment variable is the only way to set this in Rust. 

This change exposes those in the libssh2-sys crate, and wires them up as `Agent::{set_identity_path, identity_path}`. Since they handle paths, also reuses the `mkpath` util and moves it into the util module.