### PR TITLE
feat: Parse AlreadyExists error when parsing an SFTP error into an IO error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -220,6 +220,7 @@ impl From<Error> for io::Error {
             ErrorCode::Session(raw::LIBSSH2_ERROR_TIMEOUT) => io::ErrorKind::TimedOut,
             ErrorCode::SFTP(raw::LIBSSH2_FX_NO_SUCH_FILE)
             | ErrorCode::SFTP(raw::LIBSSH2_FX_NO_SUCH_PATH) => io::ErrorKind::NotFound,
+            ErrorCode::SFTP(raw::LIBSSH2_FX_FILE_ALREADY_EXISTS) => io::ErrorKind::AlreadyExists,
             _ => io::ErrorKind::Other,
         };
         io::Error::new(kind, err.msg)


### PR DESCRIPTION
When opening a file in exclusive create mode, there is the possibility of the server returning an "already exists" error, and that should be reflected when parsing an SFTP error into an io::Error