### PR TITLE
Cargo.toml: update links to repository source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong
 license = "MIT OR Apache-2.0"
 keywords = ["ssh"]
 readme = "README.md"
-repository = "https://github.com/alexcrichton/ssh2-rs"
-homepage = "https://github.com/alexcrichton/ssh2-rs"
+repository = "https://github.com/rust-lang/ssh2-rs"
+homepage = "https://github.com/rust-lang/ssh2-rs"
 documentation = "https://docs.rs/ssh2"
 description = """
 Bindings to libssh2 for interacting with SSH servers and executing remote


### PR DESCRIPTION
Update both `repository` and `homepage` to reflect the transfer to the rust-lang GitHub organization.